### PR TITLE
Tighten test assertions with minitest-strict

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,8 @@ GEM
     date (3.5.1)
     erb (6.0.4)
     minitest (5.27.0)
+    minitest-strict (1.0.0)
+      minitest (>= 5.21, < 7)
     nokogiri (1.19.2-aarch64-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.19.2-aarch64-linux-musl)
@@ -66,6 +68,7 @@ DEPENDENCIES
   bundler (>= 2.0)
   commonmarker
   minitest (~> 5.0)
+  minitest-strict (~> 1.0)
   rake (~> 13.0)
   rdiscount (~> 2.0)
   rdoc-markdown!

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Following command should run entire testsuit:
 ```
 rake test
 ```
+The test suite loads `minitest-strict`, so boolean and nil assertions only pass on exact `true`, `false`, and `nil` values.
 Testing is not excessive, just verifies that basic functionality is operational.
 
 To validate generated markdown against GitHub Flavored Markdown and check local links/anchors:

--- a/rdoc-markdown.gemspec
+++ b/rdoc-markdown.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 2.0'
   spec.add_development_dependency 'commonmarker'
   spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'minitest-strict', '~> 1.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rdiscount', '~> 2.0'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,3 +4,4 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 # require "rdoc/markdown"
 
 require "minitest/autorun"
+require "minitest/strict"

--- a/test/test_minitest_strict_integration.rb
+++ b/test/test_minitest_strict_integration.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+class TestMinitestStrictIntegration < Minitest::Test
+  def test_strict_assertions_are_loaded
+    assert_respond_to self, :assert_true
+    assert_true true
+    assert_raises(Minitest::Assertion) { assert_predicate 1, :nonzero? }
+  end
+end


### PR DESCRIPTION
## Summary
- add `minitest-strict` as a development dependency and load it from `test/test_helper.rb`
- add a focused integration test that proves the suite is running with strict assertions
- document the stricter boolean and nil assertion behavior in the testing section

## Testing
- bundle exec rake test
- bundle exec rake markdown:validate