### PR TITLE
Fix minitest cross-reference resolution

### DIFF
--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -93,6 +93,15 @@ class RDoc::Generator::Markdown
     puts "[rdoc-markdown] #{str}"
   end
 
+  # Emits a generator warning for surprising output normalization.
+  #
+  # @param str [String] Message to print.
+  #
+  # @return [void]
+  def warning(str)
+    warn("[rdoc-markdown] #{str}")
+  end
+
   # Writes a CSV search index for generated documentation.
   #
   # @return [void]
@@ -160,13 +169,15 @@ class RDoc::Generator::Markdown
     template = ERB.new(template_content, trim_mode: "-")
 
     @classes.each do |klass|
-      result = finalize_markdown(template.result(binding), current_output_path: output_path_for(klass))
+      content = template.result(binding)
+      result = finalize_markdown(content, current_output_path: output_path_for(klass))
 
       out_file = Pathname.new("#{output_dir}/#{output_path_for(klass)}")
       out_file.dirname.mkpath
       File.write(out_file, result)
 
       legacy_paths_for(klass).each do |legacy_path|
+        result = finalize_markdown(content, current_output_path: legacy_path)
         legacy_file = Pathname.new("#{output_dir}/#{legacy_path}")
         legacy_file.dirname.mkpath
         File.write(legacy_file, result)
@@ -252,13 +263,13 @@ class RDoc::Generator::Markdown
 
     html = normalize_rdoc_pre_blocks(input)
 
-    md = ReverseMarkdown.convert(html, github_flavored: true)
+    md = ReverseMarkdown.convert(html, github_flavored: true).dup
 
     # Flatten headings whose visible text is wrapped in a self-link.
     md.gsub!(/^(#+)\s\[([^\]]+)\]\((?:#[^)]+)\)$/) { "#{Regexp.last_match(1)} #{Regexp.last_match(2)}" }
 
     # Replace .html to .md extension in all local markdown links.
-    md.gsub!(%r{\]\((?!https?://|mailto:|#)([^)]+?)\.html((?:[?#][^)]+)?)\)}i) do
+    md.gsub!(%r{\]\((?!https?://|mailto:|#)([^)]+?)\.html((?:[?#][^)]*)?)\)}i) do
       "](#{Regexp.last_match(1)}.md#{Regexp.last_match(2)})"
     end
 
@@ -571,15 +582,70 @@ class RDoc::Generator::Markdown
   def normalize_internal_links(markdown, current_output_path:)
     current_dir = Pathname.new(current_output_path).dirname
 
-    markdown.gsub(%r{\]\(([^)]+)\)}) do
-      target = Regexp.last_match(1)
+    markdown.gsub(%r{\[([^\]]+)\]\(([^)]+)\)}) do
+      label = Regexp.last_match(1)
+      target = Regexp.last_match(2)
       path = target.sub(/[?#].*\z/, "")
       suffix = target[path.length..]
 
       resolved = resolve_output_path(path, current_dir)
-      rewritten = resolved ? Pathname.new(resolved).relative_path_from(current_dir) : path
-      "](#{rewritten}#{suffix})"
+      if resolved.nil? && local_markdown_link_target?(target)
+        resolved = resolve_output_path_by_label(label)
+        warning(%(resolved local link "#{target}" by label "#{plain_link_label(label)}")) if resolved
+      end
+
+      if resolved
+        rewritten = Pathname.new(resolved).relative_path_from(current_dir)
+        "[#{label}](#{rewritten}#{suffix})"
+      elsif simple_local_markdown_link?(path)
+        warning(%(removed unresolved local link "#{target}" with label "#{plain_link_label(label)}"))
+        label
+      else
+        "[#{label}](#{path}#{suffix})"
+      end
     end
+  end
+
+  # Resolves an internal link by its visible label against generated class docs.
+  #
+  # @param label [String] Markdown link label.
+  #
+  # @return [String, nil] Resolved output path, or nil when ambiguous/unresolved.
+  def resolve_output_path_by_label(label)
+    text = plain_link_label(label)
+    exact_path = @output_paths_by_reference[text]
+    return exact_path if exact_path
+
+    simple_paths = @simple_output_paths_by_reference[text]
+    simple_paths.first if simple_paths.one?
+  end
+
+  # Returns plain text from a Markdown link label.
+  #
+  # @param label [String] Markdown link label.
+  #
+  # @return [String] Label text without lightweight Markdown markup.
+  def plain_link_label(label)
+    label.delete("`")
+  end
+
+  # Checks whether an unresolved link is a simple local Markdown cross-reference.
+  #
+  # @param path [String] Link path without any query or fragment suffix.
+  #
+  # @return [Boolean] True when the link should not be emitted as broken Markdown.
+  def simple_local_markdown_link?(path)
+    path.end_with?(".md") && !path.include?("/")
+  end
+
+  # Checks whether a link target is a local Markdown document.
+  #
+  # @param target [String] Link target with any query or fragment suffix.
+  #
+  # @return [Boolean] True when the link points at a local Markdown document.
+  def local_markdown_link_target?(target)
+    path = target.sub(/[?#].*\z/, "")
+    path.end_with?(".md") && !target.match?(/\A(?:https?:\/\/|mailto:)/i)
   end
 
   # Resolves an internal link path against known generated outputs.
@@ -646,7 +712,7 @@ class RDoc::Generator::Markdown
         klass: klass,
         display_name: display_name,
         output_path: output_path,
-        legacy_paths: [legacy_path],
+        legacy_paths: (legacy_path == output_path) ? [] : [legacy_path],
         score: score
       }
 
@@ -729,12 +795,31 @@ class RDoc::Generator::Markdown
     @pages = @store.all_files.select(&:text?).select(&:display?).sort_by(&:base_name)
 
     @known_output_paths = Set.new
+    @output_paths_by_reference = {}
+    @simple_output_paths_by_reference = Hash.new { [] }
     @class_docs.each do |doc|
       @known_output_paths << doc.fetch(:output_path)
       doc.fetch(:legacy_paths).each { |path| @known_output_paths << path }
+      index_output_path_references(doc)
     end
     @pages.each { |page| @known_output_paths << page_output_path(page) }
 
     @root_path_segment = Pathname.new(@options.root || ".").basename
+  end
+
+  # Indexes generated class paths by fully-qualified and simple names.
+  #
+  # @param doc [Hash{Symbol => Object}] Class documentation metadata.
+  #
+  # @return [void]
+  def index_output_path_references(doc)
+    output_path = doc.fetch(:output_path)
+    display_name = doc.fetch(:display_name)
+
+    [display_name, doc.fetch(:klass).full_name].each do |name|
+      @output_paths_by_reference[name] = output_path
+    end
+
+    @simple_output_paths_by_reference[display_name.split("::").last] |= [output_path]
   end
 end

--- a/test/test_class_docs.rb
+++ b/test/test_class_docs.rb
@@ -175,6 +175,17 @@ class TestClassDocs < Minitest::Test
     assert_includes index_entries(dir), ["Solo::Thing", "Class", "Solo/Thing.md"]
   end
 
+  def test_generate_does_not_treat_canonical_path_as_legacy_path
+    klass = build_rdoc_class(full_name: "Plain", description: "See {Missing}[Missing.html].")
+
+    _, stderr = capture_io do
+      generate_from_store([klass])
+    end
+
+    warning = '[rdoc-markdown] removed unresolved local link "Missing.md" with label "Missing"'
+    assert_equal 1, stderr.scan(warning).count
+  end
+
   def test_generate_skips_zero_score_synthetic_classes
     synthetic = build_rdoc_class(full_name: "Root::Inner::Root::Thing")
 

--- a/test/test_markdown_helpers.rb
+++ b/test/test_markdown_helpers.rb
@@ -13,14 +13,21 @@ class TestMarkdownHelpers < Minitest::Test
   cover "RDoc::Generator::Markdown#method_description"
   cover "RDoc::Generator::Markdown#method_link"
   cover "RDoc::Generator::Markdown#section_description"
+  cover "RDoc::Generator::Markdown#setup"
   cover "RDoc::Generator::Markdown#finalize_markdown"
   cover "RDoc::Generator::Markdown#normalize_internal_links"
   cover "RDoc::Generator::Markdown#resolve_output_path"
+  cover "RDoc::Generator::Markdown#resolve_output_path_by_label"
+  cover "RDoc::Generator::Markdown#plain_link_label"
+  cover "RDoc::Generator::Markdown#simple_local_markdown_link?"
+  cover "RDoc::Generator::Markdown#local_markdown_link_target?"
   cover "RDoc::Generator::Markdown#shift_headings"
   cover "RDoc::Generator::Markdown#normalize_definition_list_code_blocks"
   cover "RDoc::Generator::Markdown#convert_definition_list_block"
   cover "RDoc::Generator::Markdown#definition_list_line?"
   cover "RDoc::Generator::Markdown#normalize_rdoc_pre_blocks"
+  cover "RDoc::Generator::Markdown#warning"
+  cover "RDoc::Generator::Markdown#index_output_path_references"
 
   def generate_markdown(classes: [], pages: [], root: nil)
     dir = stable_tmpdir("generated-markdown")
@@ -43,19 +50,26 @@ class TestMarkdownHelpers < Minitest::Test
                "{RootGuide}[/docs/root.html?x=1] {RootPlain}[/docs/plain.html] " \
                "{Secure}[https://example.com/page.html] {PlainHttp}[http://example.com/page.html] " \
                "{MailHtml}[mailto:test.html] {AnchorHtml}[#topic.html]\n" \
-               "{FilePath}[files/README.html] {ParentFile}[../files/README.html#top] " \
+               "{FilePath}[files/README.html] {FilePathAnchor}[files/README.html#top] " \
+               "{ParentFile}[../files/README.html#top] " \
                "{ClassPath}[classes/Foo.html] {ParentClass}[../classes/Foo.html#top] " \
                "{ModulePath}[modules/Bar.html] {ParentModule}[../modules/Bar.html#top]\n\n" \
                "  bird::\n  * speak\n"
     )
 
-    markdown = read_generated("guide_rdoc.md", pages: [page])
+    target = rdoc_page(relative_name: "README", comment: "= README")
+    foo = build_rdoc_class(full_name: "Foo", description: "Foo docs")
+    bar = build_rdoc_class(full_name: "Bar", description: "Bar docs")
+    markdown = nil
+    _, stderr = capture_io do
+      markdown = read_generated("guide_rdoc.md", classes: [foo, bar], pages: [page, target])
+    end
 
     assert_includes markdown, "# Heading"
-    assert_includes markdown, "[Guide](guide.md)"
+    assert_includes markdown, "Guide Upper"
+    assert_includes stderr, '[rdoc-markdown] removed unresolved local link "guide.md" with label "Guide"'
     assert_includes markdown, "[Mail](mailto:test@example.com)"
     assert_includes markdown, "[Anchor](#topic)"
-    assert_includes markdown, "[Upper](UPPER.md)"
     assert_includes markdown, "[RootGuide](docs/root.md?x=1)"
     assert_includes markdown, "[RootPlain](docs/plain.md)"
     assert_includes markdown, "[Secure](https://example.com/page.html)"
@@ -63,6 +77,7 @@ class TestMarkdownHelpers < Minitest::Test
     assert_includes markdown, "[MailHtml](mailto:test.html)"
     assert_includes markdown, "[AnchorHtml](#topic.html)"
     assert_includes markdown, "[FilePath](README.md)"
+    assert_includes markdown, "[FilePathAnchor](README.md#top)"
     assert_includes markdown, "[ParentFile](../README.md#top)"
     assert_includes markdown, "[ClassPath](Foo.md)"
     assert_includes markdown, "[ParentClass](../Foo.md#top)"
@@ -79,6 +94,22 @@ class TestMarkdownHelpers < Minitest::Test
 
     assert_includes markdown, "Intro\n\n# Topic"
     refute_includes markdown, "[Topic](#topic)"
+  end
+
+  def test_empty_reverse_markdown_results_do_not_emit_frozen_literal_warnings
+    skip "Ruby warning categories are unavailable" unless Warning.respond_to?(:[]) && Warning.respond_to?(:[]=)
+
+    original = Warning[:deprecated]
+    Warning[:deprecated] = true
+    page = rdoc_page(relative_name: "empty.rdoc", comment: "")
+
+    _, stderr = capture_io do
+      read_generated("empty_rdoc.md", pages: [page])
+    end
+
+    refute_includes stderr, "literal string will be frozen"
+  ensure
+    Warning[:deprecated] = original if defined?(original)
   end
 
   def test_multiple_rdoc_heading_levels_are_normalized
@@ -146,7 +177,10 @@ class TestMarkdownHelpers < Minitest::Test
                "[Sibling](nested/../sibling.md)"
     )
 
-    dir = generate_markdown(pages: [guide, api, sibling, simple_intro, single, empty_anchor, readme])
+    dir = nil
+    _, stderr = capture_io do
+      dir = generate_markdown(pages: [guide, api, sibling, simple_intro, single, empty_anchor, readme])
+    end
     markdown = File.read(File.join(dir, "docs/readme_rdoc.md"))
 
     assert_includes markdown, "[Intro](../guides/intro_rdoc.md#top)"
@@ -156,6 +190,7 @@ class TestMarkdownHelpers < Minitest::Test
     assert_includes markdown, "[Mail](mailto:test@example.com)"
     assert_includes markdown, "[Anchor](#topic.md)"
     assert_includes markdown, "[Sibling](sibling.md)"
+    refute_includes stderr, 'resolved local link "missing/path.md#part"'
     assert_eql "[Intro](../guides/intro_rdoc.md#top)\n", File.read(File.join(dir, "docs/single_rdoc.md"))
     assert_eql "[EmptyAnchor](../guides/intro.md#) [RootIntro](../guides/intro.md)\n",
       File.read(File.join(dir, "docs/empty-anchor_rdoc.md"))
@@ -176,6 +211,159 @@ class TestMarkdownHelpers < Minitest::Test
     assert_eql "[Direct](../guides/direct.md) [Rooted](../guides/rooted.md) " \
                "[Nested](../pages/guides/nested.md)\n",
       File.read(File.join(dir, "docs/readme_rdoc.md"))
+  end
+
+  def test_unresolved_simple_internal_links_are_rendered_as_text_with_warning
+    klass = build_rdoc_class(
+      full_name: "Minitest::Reportable",
+      description: "Shared code for anything passed to a {+Reporter+}[Reporter.html]."
+    )
+
+    markdown = nil
+    _, stderr = capture_io do
+      markdown = read_generated("Minitest/Reportable.md", classes: [klass])
+    end
+
+    assert_includes markdown, "passed to a `Reporter`."
+    refute_includes markdown, "[Reporter](Reporter.md)"
+    warning = '[rdoc-markdown] removed unresolved local link "Reporter.md" with label "Reporter"'
+    assert_includes stderr, warning
+    assert_equal 1, stderr.scan(warning).count
+    refute_includes stderr, 'with label "`Reporter`"'
+  end
+
+  def test_legacy_class_paths_finalize_links_relative_to_their_own_output
+    root = build_rdoc_class(full_name: "Minitest", description: "Root docs")
+    path_expander = build_rdoc_class(
+      full_name: "Minitest::VendoredPathExpander::Minitest::VendoredPathExpander::Minitest::PathExpander",
+      description: "Returns a hash mapping [Minitest](../../../Minitest.md) runnable classes."
+    )
+
+    dir = nil
+    _, stderr = capture_io do
+      dir = generate_markdown(classes: [root, path_expander])
+    end
+
+    assert_includes File.read(File.join(dir, "Minitest/PathExpander.md")), "[Minitest](../Minitest.md)"
+    assert_includes File.read(File.join(
+      dir,
+      "Minitest/VendoredPathExpander/Minitest/VendoredPathExpander/Minitest/PathExpander.md"
+    )), "[Minitest](../../../../../Minitest.md)"
+    assert_includes stderr, '[rdoc-markdown] resolved local link "../../../Minitest.md" by label "Minitest"'
+  end
+
+  def test_label_resolution_prefers_exact_names_when_simple_names_are_ambiguous
+    root = build_rdoc_class(full_name: "Root", description: "Root docs")
+    other_root = build_rdoc_class(full_name: "Other::Root", description: "Other root docs")
+    synthetic = build_rdoc_class(
+      full_name: "Vendored::Inner::Vendored::Thing",
+      description: "Synthetic docs"
+    )
+    source = build_rdoc_class(
+      full_name: "Docs::Thing",
+      description: "See [Root](../../Root.md), [Vendored::Thing](../../Vendored/Thing.md), " \
+                   "and [Vendored::Inner::Vendored::Thing](../../Vendored/Inner/Vendored/Thing.md)."
+    )
+
+    dir = nil
+    capture_io do
+      dir = generate_markdown(classes: [root, other_root, synthetic, source])
+    end
+
+    markdown = File.read(File.join(dir, "Docs/Thing.md"))
+
+    assert_includes markdown, "[Root](../Root.md)"
+    assert_includes markdown, "[Vendored::Thing](../Vendored/Thing.md)"
+    assert_includes markdown, "[Vendored::Inner::Vendored::Thing](../Vendored/Thing.md)"
+  end
+
+  def test_label_resolution_leaves_ambiguous_simple_names_unresolved
+    alpha = build_rdoc_class(full_name: "Alpha::Thing", description: "Alpha docs")
+    beta = build_rdoc_class(full_name: "Beta::Thing", description: "Beta docs")
+    page = rdoc_page(relative_name: "docs/ambiguous.rdoc", comment: "See [Thing](../Thing.md).")
+
+    dir = nil
+    _, stderr = capture_io do
+      dir = generate_markdown(classes: [alpha, beta], pages: [page])
+    end
+
+    assert_includes File.read(File.join(dir, "docs/ambiguous_rdoc.md")), "[Thing](../Thing.md)"
+    refute_includes stderr, 'resolved local link "../Thing.md" by label "Thing"'
+  end
+
+  def test_label_resolution_uses_unambiguous_simple_names
+    target = build_rdoc_class(full_name: "Namespace::Thing", description: "Target docs")
+    source = build_rdoc_class(
+      full_name: "Docs::Source",
+      description: "See {+Thing+}[../Thing.html]."
+    )
+
+    dir = nil
+    _, stderr = capture_io do
+      dir = generate_markdown(classes: [target, source])
+    end
+
+    assert_includes File.read(File.join(dir, "Docs/Source.md")), "[`Thing`](../Namespace/Thing.md)"
+    assert_includes stderr, 'resolved local link "../Thing.md" by label "Thing"'
+    refute_includes stderr, 'by label "`Thing`"'
+  end
+
+  def test_label_resolution_only_uses_local_markdown_targets
+    target = build_rdoc_class(full_name: "Namespace::Thing", description: "Target docs")
+    page = rdoc_page(
+      relative_name: "docs/targets.rdoc",
+      comment: "See {Thing}[../Thing.html#], {Thing}[../Thing.html#topic], " \
+               "{Thing}[../Thing.html?version=1], {Thing}[http://example.com/Thing.md], " \
+               "{Thing}[HTTPS://example.com/Thing.md], " \
+               "{Thing}[#Thing.md], and {Thing}[Thing.txt]."
+    )
+
+    dir = nil
+    capture_io do
+      dir = generate_markdown(classes: [target], pages: [page])
+    end
+
+    markdown = File.read(File.join(dir, "docs/targets_rdoc.md"))
+
+    assert_includes markdown, "[Thing](../Namespace/Thing.md#)"
+    assert_includes markdown, "[Thing](../Namespace/Thing.md#topic)"
+    assert_includes markdown, "[Thing](../Namespace/Thing.md?version=1)"
+    assert_includes markdown, "[Thing](http://example.com/Thing.md)"
+    assert_includes markdown, "[Thing](HTTPS://example.com/Thing.md)"
+    assert_includes markdown, "[Thing](#Thing.md)"
+    assert_includes markdown, "[Thing](Thing.txt)"
+  end
+
+  def test_label_resolution_does_not_rewrite_mailto_markdown_targets
+    raw_page_class = Struct.new(:relative_name, :description, :store) do
+      def text?
+        true
+      end
+
+      def display?
+        true
+      end
+
+      def base_name
+        File.basename(relative_name)
+      end
+
+      def page_name
+        File.basename(relative_name, ".*")
+      end
+    end
+    target = build_rdoc_class(full_name: "Namespace::Thing", description: "Target docs")
+    page = raw_page_class.new(
+      "docs/mailto.raw",
+      'See <a href="mailto:test@example.com/Thing.md">Thing</a>.'
+    )
+
+    dir = nil
+    capture_io do
+      dir = generate_markdown(classes: [target], pages: [page])
+    end
+
+    assert_includes File.read(File.join(dir, "docs/mailto_raw.md")), "[Thing](mailto:test@example.com/Thing.md)"
   end
 
   def test_class_and_method_descriptions_are_markdownified

--- a/test/test_minitest_harness.rb
+++ b/test/test_minitest_harness.rb
@@ -34,7 +34,9 @@ class TestMinitestHarness < Minitest::Test
     options.root = minitest_root
     options.title = "minitest harness"
 
-    RDoc::RDoc.new.document(options)
+    _, stderr = capture_io do
+      RDoc::RDoc.new.document(options)
+    end
 
     assert File.exist?(File.join(out_dir, "README_rdoc.md"))
     assert File.exist?(File.join(out_dir, "History_rdoc.md"))
@@ -42,6 +44,11 @@ class TestMinitestHarness < Minitest::Test
     assert File.exist?(File.join(out_dir, "Minitest/PathExpander.md"))
 
     readme_md = File.read(File.join(out_dir, "README_rdoc.md"))
+    reportable_md = File.read(File.join(out_dir, "Minitest/Reportable.md"))
+    path_expander_md = File.read(File.join(
+      out_dir,
+      "Minitest/VendoredPathExpander/Minitest/VendoredPathExpander/Minitest/PathExpander.md"
+    ))
 
     assert_includes readme_md, "# minitest/{test,spec,benchmark}"
     assert_includes readme_md, "## DESCRIPTION:"
@@ -50,6 +57,11 @@ class TestMinitestHarness < Minitest::Test
     assert_includes readme_md, "class Meme\n  def i_can_has_cheezburger?"
     assert_includes readme_md, "[assertions](Minitest/Assertions.md)"
     refute_match(%r{\]\((?!https?://|mailto:|#)[^)]+\.html(?:[?#][^)]+)?\)}, readme_md)
+    assert_includes reportable_md, "passed to a `Reporter`."
+    refute_includes reportable_md, "[Reporter](Reporter.md)"
+    assert_includes path_expander_md, "[`Minitest`](../../../../../Minitest.md) runnable classes"
+    assert_includes stderr, '[rdoc-markdown] removed unresolved local link "Reporter.md" with label "Reporter"'
+    assert_includes stderr, '[rdoc-markdown] resolved local link "../../../Minitest.md" by label "Minitest"'
 
     csv_rows = CSV.parse(File.read(File.join(out_dir, "index.csv")), headers: true)
 


### PR DESCRIPTION
## Summary
- Resolve local Markdown links by generated class names when RDoc emits a relative path that does not map directly to an output file.
- Render unresolved simple local documentation links as plain text and emit warnings instead of leaving broken Markdown links.
- Finalize mirrored legacy class files relative to their own output path so nested compatibility files get correct relative links.

## Verification
- `bundle exec rake test`
- `bundle exec mutant run`
- `bundle exec rake markdown:validate`
- `bundle exec yard-lint`
- `bundle exec rake erb:lint`
- `bundle exec standardrb`

Closes #59