### PR TITLE
Fix rdof-ref placeholder links

### DIFF
--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -571,15 +571,60 @@ class RDoc::Generator::Markdown
   def normalize_internal_links(markdown, current_output_path:)
     current_dir = Pathname.new(current_output_path).dirname
 
-    markdown.gsub(%r{\]\(([^)]+)\)}) do
-      target = Regexp.last_match(1)
+    markdown.gsub(%r{(!?)\[([^\]]+)\]\(([^)]+)\)}) do
+      image_marker = Regexp.last_match(1)
+      label = Regexp.last_match(2)
+      target = Regexp.last_match(3)
+      if target.start_with?("rdof-ref:")
+        next normalize_rdof_reference_link(label, target, current_dir)
+      end
+
       path = target.sub(/[?#].*\z/, "")
       suffix = target[path.length..]
 
       resolved = resolve_output_path(path, current_dir)
       rewritten = resolved ? Pathname.new(resolved).relative_path_from(current_dir) : path
-      "](#{rewritten}#{suffix})"
+      "#{image_marker}[#{label}](#{rewritten}#{suffix})"
     end
+  end
+
+  # Converts a leaked rdof-ref Markdown link to a generated link or plain text.
+  #
+  # @param label [String] Link text.
+  # @param target [String] Link target beginning with rdof-ref:.
+  # @param current_dir [Pathname] Directory of the current output file.
+  #
+  # @return [String] Markdown link or plain text label.
+  def normalize_rdof_reference_link(label, target, current_dir)
+    resolved = resolve_rdof_reference(target.delete_prefix("rdof-ref:"))
+    unless resolved
+      warn %([rdoc-markdown] removed unresolved rdof-ref link #{target.inspect} with label #{label.inspect})
+      return label
+    end
+
+    relative = Pathname.new(resolved).relative_path_from(current_dir)
+    warn %([rdoc-markdown] resolved rdof-ref link #{target.inspect} to #{relative})
+    "[#{label}](#{relative})"
+  end
+
+  # Resolves a typoed rdof-ref target against generated class and method docs.
+  #
+  # @param reference [String] Reference without the rdof-ref: scheme.
+  #
+  # @return [String, nil] Output path with optional anchor, or nil when unknown.
+  def resolve_rdof_reference(reference)
+    if (match = reference.match(/\A(.+)#([^#]+)\z/))
+      doc = @class_docs_by_reference_name[match[1]]
+      return unless doc
+
+      method = doc.fetch(:klass).method_list.find { |candidate| candidate.name == match[2] }
+      return unless method
+
+      return "#{doc.fetch(:output_path)}##{method.aref}"
+    end
+
+    doc = @class_docs_by_reference_name[reference]
+    doc&.fetch(:output_path)
   end
 
   # Resolves an internal link path against known generated outputs.
@@ -725,6 +770,7 @@ class RDoc::Generator::Markdown
 
     @class_docs = build_class_docs(@store.all_classes_and_modules.sort)
     @class_docs_by_object_id = @class_docs.to_h { |doc| [doc.fetch(:klass).object_id, doc] }
+    @class_docs_by_reference_name = @class_docs.to_h { |doc| [doc.fetch(:display_name), doc] }
     @classes = @class_docs.map { |doc| doc.fetch(:klass) }
     @pages = @store.all_files.select(&:text?).select(&:display?).sort_by(&:base_name)
 

--- a/test/test_markdown_helpers.rb
+++ b/test/test_markdown_helpers.rb
@@ -15,7 +15,10 @@ class TestMarkdownHelpers < Minitest::Test
   cover "RDoc::Generator::Markdown#section_description"
   cover "RDoc::Generator::Markdown#finalize_markdown"
   cover "RDoc::Generator::Markdown#normalize_internal_links"
+  cover "RDoc::Generator::Markdown#normalize_rdof_reference_link"
+  cover "RDoc::Generator::Markdown#resolve_rdof_reference"
   cover "RDoc::Generator::Markdown#resolve_output_path"
+  cover "RDoc::Generator::Markdown#setup"
   cover "RDoc::Generator::Markdown#shift_headings"
   cover "RDoc::Generator::Markdown#normalize_definition_list_code_blocks"
   cover "RDoc::Generator::Markdown#convert_definition_list_block"
@@ -142,8 +145,8 @@ class TestMarkdownHelpers < Minitest::Test
       relative_name: "docs/readme.rdoc",
       comment: "{Intro}[guides/intro_rdoc.html#top] {API}[guides/api_rdoc.html] " \
                 "{Missing}[missing/path.html#part] {Secure}[https://example.com/page.md] " \
-               "{Mail}[mailto:test@example.com] {Anchor}[#topic.md] " \
-               "[Sibling](nested/../sibling.md)"
+                "{Mail}[mailto:test@example.com] {Anchor}[#topic.md] " \
+               "[Sibling](nested/../sibling.md) ![Diagram](nested/../sibling.md)"
     )
 
     dir = generate_markdown(pages: [guide, api, sibling, simple_intro, single, empty_anchor, readme])
@@ -156,6 +159,7 @@ class TestMarkdownHelpers < Minitest::Test
     assert_includes markdown, "[Mail](mailto:test@example.com)"
     assert_includes markdown, "[Anchor](#topic.md)"
     assert_includes markdown, "[Sibling](sibling.md)"
+    assert_includes markdown, "![Diagram](sibling.md)"
     assert_eql "[Intro](../guides/intro_rdoc.md#top)\n", File.read(File.join(dir, "docs/single_rdoc.md"))
     assert_eql "[EmptyAnchor](../guides/intro.md#) [RootIntro](../guides/intro.md)\n",
       File.read(File.join(dir, "docs/empty-anchor_rdoc.md"))
@@ -176,6 +180,64 @@ class TestMarkdownHelpers < Minitest::Test
     assert_eql "[Direct](../guides/direct.md) [Rooted](../guides/rooted.md) " \
                "[Nested](../pages/guides/nested.md)\n",
       File.read(File.join(dir, "docs/readme_rdoc.md"))
+  end
+
+  def test_rdof_ref_links_resolve_to_generated_class_and_method_links
+    form_helper = build_rdoc_class(full_name: "ActionView::Helpers::FormHelper", description: "Form helper")
+    form_helper.add_method(rdoc_method("build", visible: true, comment: "Other target"))
+    form_helper.add_method(rdoc_method("form_with", visible: true, comment: "Target"))
+    form_helper.add_method(rdoc_method("finish", visible: true, comment: "Other target"))
+    page = rdoc_page(
+      relative_name: "ActionView/Helpers/FormBuilder.rdoc",
+      comment: "See {FormHelper}[rdof-ref:ActionView::Helpers::FormHelper] and " \
+               "{form_with}[rdof-ref:ActionView::Helpers::FormHelper#form_with]."
+    )
+
+    dir = nil
+    _stdout, stderr = capture_io do
+      dir = generate_markdown(classes: [form_helper], pages: [page])
+    end
+    markdown = File.read(File.join(dir, "ActionView/Helpers/FormBuilder_rdoc.md"))
+
+    assert_includes markdown, "[FormHelper](FormHelper.md)"
+    assert_includes markdown, "[form\\_with](FormHelper.md#method-i-form_with)"
+    refute_includes markdown, "rdof-ref:"
+    assert_includes stderr,
+      '[rdoc-markdown] resolved rdof-ref link "rdof-ref:ActionView::Helpers::FormHelper" to FormHelper.md'
+    assert_includes stderr,
+      '[rdoc-markdown] resolved rdof-ref link "rdof-ref:ActionView::Helpers::FormHelper#form_with" '
+  end
+
+  def test_unresolved_rdof_ref_links_render_plain_text_with_warning
+    form_helper = build_rdoc_class(full_name: "ActionView::Helpers::FormHelper", description: "Form helper")
+    form_helper.add_method(rdoc_method("other", visible: true, comment: "Other target"))
+    page = rdoc_page(
+      relative_name: "ActionView/Helpers/FormBuilder.rdoc",
+      comment: "See {missing class}[rdof-ref:ActionView::Helpers::Missing#form_with] and " \
+               "{missing method}[rdof-ref:ActionView::Helpers::FormHelper#form_with] and " \
+               "{missing target}[rdof-ref:ActionView::Helpers::Unknown]."
+    )
+
+    dir = nil
+    _stdout, stderr = capture_io do
+      dir = generate_markdown(classes: [form_helper], pages: [page])
+    end
+    markdown = File.read(File.join(dir, "ActionView/Helpers/FormBuilder_rdoc.md"))
+
+    assert_includes markdown, "See missing class and missing method and missing target."
+    refute_includes markdown, "rdof-ref:"
+    refute_includes markdown, "[missing class]"
+    refute_includes markdown, "[missing method]"
+    refute_includes markdown, "[missing target]"
+    assert_includes stderr,
+      '[rdoc-markdown] removed unresolved rdof-ref link "rdof-ref:ActionView::Helpers::Missing#form_with" ' \
+      'with label "missing class"'
+    assert_includes stderr,
+      '[rdoc-markdown] removed unresolved rdof-ref link "rdof-ref:ActionView::Helpers::FormHelper#form_with" ' \
+      'with label "missing method"'
+    assert_includes stderr,
+      '[rdoc-markdown] removed unresolved rdof-ref link "rdof-ref:ActionView::Helpers::Unknown" ' \
+      'with label "missing target"'
   end
 
   def test_class_and_method_descriptions_are_markdownified


### PR DESCRIPTION
## Summary
- Resolve leaked `rdof-ref:` Markdown links against generated class and method docs.
- Render unresolved `rdof-ref:` links as plain text and emit warnings instead of leaving internal placeholders in output.
- Preserve image-link rewriting while normalizing full Markdown links.

## Verification
- `bundle exec rake test`
- `bundle exec mutant run`
- `bundle exec rake markdown:validate`
- `bundle exec yard-lint`
- `bundle exec rake erb:lint`
- `bundle exec standardrb`
- `git diff --check`
- Targeted Rails generation for `ActionView::Helpers::FormBuilder` confirms no `rdof-ref:` leak.

Closes #64