### PR TITLE
Guard markdown output directory

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -97,7 +97,7 @@ def ensure_git_checkout(path:, url:, ref: nil)
   sh clone_command.join(" ")
 end
 
-def generate_markdown_docs(title:, root:, output:, files:, markdown_namespaces: nil)
+def generate_markdown_docs(title:, root:, output:, files:)
   raise "No input files for #{title}" if files.empty?
 
   FileUtils.rm_rf(output)
@@ -111,7 +111,6 @@ def generate_markdown_docs(title:, root:, output:, files:, markdown_namespaces: 
   options.root = root
   options.title = title
   options.force_output = true
-  options.generator_options = {markdown_namespaces: markdown_namespaces} unless markdown_namespaces.nil?
 
   RDoc::RDoc.new.document(options)
 end
@@ -139,8 +138,7 @@ def generate_jekyll_seo_tag_docs(output:)
     title: JEKYLL_SEO_TAG_TITLE,
     root: root,
     output: output,
-    files: Dir[File.join(root, "lib/**/*.rb")].uniq,
-    markdown_namespaces: ["Jekyll::SeoTag"]
+    files: Dir[File.join(root, "lib/**/*.rb")].uniq
   )
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -97,7 +97,7 @@ def ensure_git_checkout(path:, url:, ref: nil)
   sh clone_command.join(" ")
 end
 
-def generate_markdown_docs(title:, root:, output:, files:)
+def generate_markdown_docs(title:, root:, output:, files:, markdown_namespaces: nil)
   raise "No input files for #{title}" if files.empty?
 
   FileUtils.rm_rf(output)
@@ -111,6 +111,7 @@ def generate_markdown_docs(title:, root:, output:, files:)
   options.root = root
   options.title = title
   options.force_output = true
+  options.generator_options = {markdown_namespaces: markdown_namespaces} unless markdown_namespaces.nil?
 
   RDoc::RDoc.new.document(options)
 end
@@ -138,7 +139,8 @@ def generate_jekyll_seo_tag_docs(output:)
     title: JEKYLL_SEO_TAG_TITLE,
     root: root,
     output: output,
-    files: Dir[File.join(root, "lib/**/*.rb")].uniq
+    files: Dir[File.join(root, "lib/**/*.rb")].uniq,
+    markdown_namespaces: ["Jekyll::SeoTag"]
   )
 end
 

--- a/example/jekyll-seo-tag/Jekyll.md
+++ b/example/jekyll-seo-tag/Jekyll.md
@@ -1,0 +1,3 @@
+# Module Jekyll
+<a id="module-jekyll"></a>
+

--- a/example/jekyll-seo-tag/Liquid.md
+++ b/example/jekyll-seo-tag/Liquid.md
@@ -1,0 +1,5 @@
+# Module Liquid
+<a id="module-liquid"></a>
+
+Prevent bundler errors
+

--- a/example/jekyll-seo-tag/Liquid/Tag.md
+++ b/example/jekyll-seo-tag/Liquid/Tag.md
@@ -1,0 +1,3 @@
+# Class Liquid::Tag
+<a id="class-liquid-tag"></a>
+

--- a/example/jekyll-seo-tag/index.csv
+++ b/example/jekyll-seo-tag/index.csv
@@ -1,4 +1,5 @@
 name,type,path
+Jekyll,Module,Jekyll.md
 Jekyll::SeoTag,Class,Jekyll/SeoTag.md
 Jekyll::SeoTag.new,Method,Jekyll/SeoTag.md#method-c-new
 Jekyll::SeoTag.render,Method,Jekyll/SeoTag.md#method-i-render
@@ -55,3 +56,5 @@ Jekyll::SeoTag::JSONLDDrop.publisher,Method,Jekyll/SeoTag/JSONLDDrop.md#method-i
 Jekyll::SeoTag::JSONLDDrop.mainEntityOfPage,Method,Jekyll/SeoTag/JSONLDDrop.md#method-i-mainEntityOfPage
 Jekyll::SeoTag::JSONLDDrop.to_json,Method,Jekyll/SeoTag/JSONLDDrop.md#method-i-to_json
 Jekyll::SeoTag::UrlHelper,Module,Jekyll/SeoTag/UrlHelper.md
+Liquid,Module,Liquid.md
+Liquid::Tag,Class,Liquid/Tag.md

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -752,6 +752,9 @@ class RDoc::Generator::Markdown
   # @return [void]
   def setup
     @output_dir = @options.op_dir
+    unless @output_dir.instance_of?(String)
+      raise TypeError, "RDoc markdown output directory must be a String"
+    end
 
     @class_docs = build_class_docs(@store.all_classes_and_modules.sort)
     @class_docs_by_object_id = @class_docs.to_h { |doc| [doc.fetch(:klass).object_id, doc] }

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -636,8 +636,10 @@ class RDoc::Generator::Markdown
   def build_class_docs(classes)
     docs_by_name = {}
 
-    classes.each do |klass|
+    classes.select(&:display?).each do |klass|
       display_name = normalized_full_name(klass.full_name)
+      next unless markdown_namespace_included?(display_name)
+
       output_path = turn_to_path(display_name)
       legacy_path = turn_to_path(klass.full_name)
       score = class_content_score(klass)
@@ -665,23 +667,13 @@ class RDoc::Generator::Markdown
     end
 
     docs_by_name.values
-      .select { |doc| documentable_class_doc?(doc) }
+      .select do |doc|
+        klass = doc.fetch(:klass)
+
+        doc.fetch(:score).positive? ||
+          (!class_has_raw_members?(klass) && !synthetic_full_name?(klass.full_name))
+      end
       .sort_by { |doc| doc.fetch(:display_name) }
-  end
-
-  # Checks whether a normalized class/module candidate should be rendered.
-  #
-  # @param doc [Hash{Symbol => Object}] Candidate class documentation metadata.
-  #
-  # @return [Boolean] True when the class/module has useful generated output.
-  def documentable_class_doc?(doc)
-    klass = doc.fetch(:klass)
-
-    return true if class_member_count(klass).positive?
-    return false if klass.description.empty?
-    return true if nested_classes_and_modules(klass).empty?
-
-    subtree_member_count(klass).positive?
   end
 
   # Collapses repeated namespace segments from synthetic vendored names.
@@ -724,27 +716,50 @@ class RDoc::Generator::Markdown
   #
   # @return [Integer] Number of owned members.
   def class_member_count(klass)
-    klass.method_list.size + klass.constants.size + klass.attributes.size
+    klass.method_list.count(&:display?) + klass.constants.count(&:display?) + klass.attributes.count(&:display?)
   end
 
-  # Counts methods, constants, and attributes owned by nested classes/modules.
+  # Checks whether a class or module owns any members before display filtering.
   #
   # @param klass [RDoc::Context] Class or module object.
   #
-  # @return [Integer] Number of descendant members.
-  def subtree_member_count(klass)
-    nested_classes_and_modules(klass).sum do |child|
-      class_member_count(child) + subtree_member_count(child)
+  # @return [Boolean] True when any owned member exists before display filtering.
+  def class_has_raw_members?(klass)
+    klass.method_list.any? || klass.constants.any? || klass.attributes.any?
+  end
+
+  # Checks whether a name appears to contain duplicated root namespaces.
+  #
+  # @param full_name [String] Full RDoc object name.
+  #
+  # @return [Boolean] True when the root namespace appears more than once.
+  def synthetic_full_name?(full_name)
+    parts = full_name.split("::")
+    root = parts.first
+    parts.count(root) > 1
+  end
+
+  # Checks whether a normalized class/module name is within the requested output namespaces.
+  #
+  # @param display_name [String] Normalized class/module name.
+  #
+  # @return [Boolean] True when no namespace filter is configured or the name is included.
+  def markdown_namespace_included?(display_name)
+    namespaces = markdown_namespaces
+
+    namespaces.empty? || namespaces.any? do |namespace|
+      display_name == namespace || display_name.start_with?("#{namespace}::")
     end
   end
 
-  # Returns nested classes and modules owned by a class/module object.
+  # Explicit class/module namespaces requested by the caller.
   #
-  # @param klass [RDoc::Context] Class or module object.
-  #
-  # @return [Array<RDoc::Context>] Direct nested classes and modules.
-  def nested_classes_and_modules(klass)
-    klass.classes + klass.modules
+  # @return [Array<String>] Namespace roots to generate, or an empty array for all namespaces.
+  def markdown_namespaces
+    @markdown_namespaces ||= begin
+      generator_options = @options.generator_options
+      generator_options.instance_of?(Hash) ? (generator_options[:markdown_namespaces] || []) : []
+    end
   end
 
   # Prepares sorted objects and link lookup state for generation.

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -638,8 +638,6 @@ class RDoc::Generator::Markdown
 
     classes.select(&:display?).each do |klass|
       display_name = normalized_full_name(klass.full_name)
-      next unless markdown_namespace_included?(display_name)
-
       output_path = turn_to_path(display_name)
       legacy_path = turn_to_path(klass.full_name)
       score = class_content_score(klass)
@@ -737,29 +735,6 @@ class RDoc::Generator::Markdown
     parts = full_name.split("::")
     root = parts.first
     parts.count(root) > 1
-  end
-
-  # Checks whether a normalized class/module name is within the requested output namespaces.
-  #
-  # @param display_name [String] Normalized class/module name.
-  #
-  # @return [Boolean] True when no namespace filter is configured or the name is included.
-  def markdown_namespace_included?(display_name)
-    namespaces = markdown_namespaces
-
-    namespaces.empty? || namespaces.any? do |namespace|
-      display_name == namespace || display_name.start_with?("#{namespace}::")
-    end
-  end
-
-  # Explicit class/module namespaces requested by the caller.
-  #
-  # @return [Array<String>] Namespace roots to generate, or an empty array for all namespaces.
-  def markdown_namespaces
-    @markdown_namespaces ||= begin
-      generator_options = @options.generator_options
-      generator_options.instance_of?(Hash) ? (generator_options[:markdown_namespaces] || []) : []
-    end
   end
 
   # Prepares sorted objects and link lookup state for generation.

--- a/lib/templates/classfile.md.erb
+++ b/lib/templates/classfile.md.erb
@@ -41,6 +41,7 @@
 <%- end -%>
 <% klass.methods_by_type(section).each do |type, visibilities| -%>
 <% visibilities.each do |visibility, methods| -%>
+<% methods = methods.select(&:display?) -%>
 <% next if methods.empty? -%>
 
 ### <%= visibility.capitalize %> <%= type.capitalize %> Methods

--- a/test/data/namespaced_example.rb
+++ b/test/data/namespaced_example.rb
@@ -1,8 +1,6 @@
 module Ocean
   module Deep
     class Salmon
-      def swim
-      end
     end
   end
 end

--- a/test/support/rdoc.rb
+++ b/test/support/rdoc.rb
@@ -3,11 +3,10 @@
 require "rdoc/rdoc"
 
 module RDocTestHelpers
-  def generator_options(op_dir:, root: nil, markdown_namespaces: nil)
+  def generator_options(op_dir:, root: nil)
     RDoc::Options.new.tap do |options|
       options.op_dir = op_dir
       options.root = root
-      options.generator_options = {markdown_namespaces: markdown_namespaces} unless markdown_namespaces.nil?
     end
   end
 

--- a/test/support/rdoc.rb
+++ b/test/support/rdoc.rb
@@ -3,10 +3,11 @@
 require "rdoc/rdoc"
 
 module RDocTestHelpers
-  def generator_options(op_dir:, root: nil)
+  def generator_options(op_dir:, root: nil, markdown_namespaces: nil)
     RDoc::Options.new.tap do |options|
       options.op_dir = op_dir
       options.root = root
+      options.generator_options = {markdown_namespaces: markdown_namespaces} unless markdown_namespaces.nil?
     end
   end
 
@@ -56,9 +57,9 @@ module RDocTestHelpers
       klass.full_name = full_name
       klass.add_comment(RDoc::Comment.new(description), location) unless description.nil?
 
-      Array.new(methods) { |index| klass.add_method(rdoc_method("hidden_#{index}", visible: false)) }
-      Array.new(constants) { |index| klass.add_constant(rdoc_constant("CONST_#{index}", visible: false)) }
-      Array.new(attributes) { |index| klass.add_attribute(rdoc_attribute("attribute_#{index}", visible: false)) }
+      Array.new(methods) { |index| klass.add_method(rdoc_method("method_#{index}")) }
+      Array.new(constants) { |index| klass.add_constant(rdoc_constant("CONST_#{index}")) }
+      Array.new(attributes) { |index| klass.add_attribute(rdoc_attribute("attribute_#{index}")) }
     end
   end
 
@@ -72,9 +73,9 @@ module RDocTestHelpers
       mod.full_name = full_name
       mod.add_comment(RDoc::Comment.new(description), location) unless description.nil?
 
-      Array.new(methods) { |index| mod.add_method(rdoc_method("hidden_#{index}", visible: false)) }
-      Array.new(constants) { |index| mod.add_constant(rdoc_constant("CONST_#{index}", visible: false)) }
-      Array.new(attributes) { |index| mod.add_attribute(rdoc_attribute("attribute_#{index}", visible: false)) }
+      Array.new(methods) { |index| mod.add_method(rdoc_method("method_#{index}")) }
+      Array.new(constants) { |index| mod.add_constant(rdoc_constant("CONST_#{index}")) }
+      Array.new(attributes) { |index| mod.add_attribute(rdoc_attribute("attribute_#{index}")) }
     end
   end
 

--- a/test/test_class_docs.rb
+++ b/test/test_class_docs.rb
@@ -9,22 +9,26 @@ require "rdoc/markdown"
 class TestClassDocs < Minitest::Test
   cover "RDoc::Generator::Markdown#build_class_docs"
   cover "RDoc::Generator::Markdown#class_member_count"
+  cover "RDoc::Generator::Markdown#class_has_raw_members?"
   cover "RDoc::Generator::Markdown#class_content_score"
   cover "RDoc::Generator::Markdown#class_doc_for"
-  cover "RDoc::Generator::Markdown#documentable_class_doc?"
   cover "RDoc::Generator::Markdown#display_name"
   cover "RDoc::Generator::Markdown#emit_classfiles"
   cover "RDoc::Generator::Markdown#emit_csv_index"
   cover "RDoc::Generator::Markdown#generate"
   cover "RDoc::Generator::Markdown#legacy_paths_for"
-  cover "RDoc::Generator::Markdown#nested_classes_and_modules"
+  cover "RDoc::Generator::Markdown#markdown_namespace_included?"
+  cover "RDoc::Generator::Markdown#markdown_namespaces"
   cover "RDoc::Generator::Markdown#normalized_full_name"
   cover "RDoc::Generator::Markdown#output_path_for"
   cover "RDoc::Generator::Markdown#setup"
-  cover "RDoc::Generator::Markdown#subtree_member_count"
+  cover "RDoc::Generator::Markdown#synthetic_full_name?"
 
-  def generate_from_store(classes, pages: nil, dir: stable_tmpdir("generate-from-store"), root: nil)
-    generator = RDoc::Generator::Markdown.new(rdoc_store(classes: classes, pages: pages), generator_options(op_dir: dir, root: root))
+  def generate_from_store(classes, pages: nil, dir: stable_tmpdir("generate-from-store"), root: nil, markdown_namespaces: nil)
+    generator = RDoc::Generator::Markdown.new(
+      rdoc_store(classes: classes, pages: pages),
+      generator_options(op_dir: dir, root: root, markdown_namespaces: markdown_namespaces)
+    )
     generator.generate
     dir
   end
@@ -215,68 +219,166 @@ class TestClassDocs < Minitest::Test
     assert_predicate index_entries(dir), :empty?
   end
 
-  def test_generate_skips_zero_score_real_declarations
+  def test_generate_skips_hidden_only_member_declarations
+    hidden_method = build_rdoc_class(full_name: "HiddenMethodOnly")
+    hidden_method.add_method(rdoc_method("hidden_method", visible: false))
+    hidden_constant = build_rdoc_class(full_name: "HiddenConstantOnly")
+    hidden_constant.add_constant(rdoc_constant("HIDDEN", visible: false))
+    hidden_attribute = build_rdoc_class(full_name: "HiddenAttributeOnly")
+    hidden_attribute.add_attribute(rdoc_attribute("hidden_attribute", visible: false))
+
+    dir = generate_from_store([hidden_method, hidden_constant, hidden_attribute])
+
+    assert_false File.exist?(File.join(dir, "HiddenMethodOnly.md"))
+    assert_false File.exist?(File.join(dir, "HiddenConstantOnly.md"))
+    assert_false File.exist?(File.join(dir, "HiddenAttributeOnly.md"))
+    assert_predicate index_entries(dir), :empty?
+  end
+
+  def test_generate_keeps_namespace_when_hidden_descendants_are_skipped
+    namespace = build_rdoc_module(full_name: "HiddenNamespace")
+    hidden_child = build_rdoc_class(full_name: "HiddenNamespace::Child")
+    hidden_child.add_method(rdoc_method("hidden_method", visible: false))
+    nest_class(namespace, hidden_child)
+
+    dir = generate_from_store([namespace, hidden_child])
+
+    assert_true File.exist?(File.join(dir, "HiddenNamespace.md"))
+    assert_false File.exist?(File.join(dir, "HiddenNamespace/Child.md"))
+    assert_includes index_entries(dir), ["HiddenNamespace", "Module", "HiddenNamespace.md"]
+  end
+
+  def test_generate_skips_hidden_class_before_resolving_duplicate_docs
+    hidden = build_rdoc_class(
+      full_name: "VisibleDupe::Hidden::VisibleDupe::Thing",
+      description: "Hidden duplicate",
+      methods: 2
+    )
+    hidden.done_documenting = true
+    visible = build_rdoc_class(
+      full_name: "VisibleDupe::Thing",
+      description: "Visible duplicate",
+      methods: 1
+    )
+
+    dir = generate_from_store([hidden, visible])
+
+    markdown = File.read(File.join(dir, "VisibleDupe/Thing.md"))
+    assert_includes markdown, "Visible duplicate"
+    refute_includes markdown, "Hidden duplicate"
+    assert_false File.exist?(File.join(dir, "VisibleDupe/Hidden/VisibleDupe/Thing.md"))
+    assert_includes index_entries(dir), ["VisibleDupe::Thing", "Class", "VisibleDupe/Thing.md"]
+  end
+
+  def test_generate_keeps_zero_score_real_classes
     real = build_rdoc_class(full_name: "Shell")
     nested = build_rdoc_class(full_name: "Alpha::Another")
 
     dir = generate_from_store([real, nested])
 
-    assert_false File.exist?(File.join(dir, "Shell.md"))
-    assert_false File.exist?(File.join(dir, "Alpha/Another.md"))
-    assert_predicate index_entries(dir), :empty?
+    assert_true File.exist?(File.join(dir, "Shell.md"))
+    assert_true File.exist?(File.join(dir, "Alpha/Another.md"))
+    assert_includes index_entries(dir), ["Shell", "Class", "Shell.md"]
+    assert_includes index_entries(dir), ["Alpha::Another", "Class", "Alpha/Another.md"]
   end
 
-  def test_generate_skips_empty_namespace_modules_that_only_contain_documented_children
+  def test_generate_keeps_empty_namespace_modules_that_contain_documented_children
     namespace = build_rdoc_module(full_name: "Jekyll")
     child = build_rdoc_class(full_name: "Jekyll::SeoTag", methods: 1)
     nest_class(namespace, child)
 
     dir = generate_from_store([namespace, child])
 
-    assert_false File.exist?(File.join(dir, "Jekyll.md"))
+    assert_true File.exist?(File.join(dir, "Jekyll.md"))
     assert_true File.exist?(File.join(dir, "Jekyll/SeoTag.md"))
-    refute_includes index_entries(dir), ["Jekyll", "Module", "Jekyll.md"]
+    assert_includes index_entries(dir), ["Jekyll", "Module", "Jekyll.md"]
     assert_includes index_entries(dir), ["Jekyll::SeoTag", "Class", "Jekyll/SeoTag.md"]
   end
 
-  def test_generate_skips_empty_namespace_modules_that_only_contain_nested_modules
+  def test_generate_keeps_empty_namespace_modules_that_contain_nested_modules
     namespace = build_rdoc_module(full_name: "Jekyll")
     child = build_rdoc_module(full_name: "Jekyll::SeoTag", methods: 1)
     nest_module(namespace, child)
 
     dir = generate_from_store([namespace, child])
 
-    assert_false File.exist?(File.join(dir, "Jekyll.md"))
+    assert_true File.exist?(File.join(dir, "Jekyll.md"))
     assert_true File.exist?(File.join(dir, "Jekyll/SeoTag.md"))
-    refute_includes index_entries(dir), ["Jekyll", "Module", "Jekyll.md"]
+    assert_includes index_entries(dir), ["Jekyll", "Module", "Jekyll.md"]
     assert_includes index_entries(dir), ["Jekyll::SeoTag", "Module", "Jekyll/SeoTag.md"]
   end
 
-  def test_generate_skips_described_namespace_without_api_descendants
+  def test_generate_filters_to_explicit_markdown_namespaces
+    namespace = build_rdoc_module(full_name: "Jekyll")
+    seo_tag = build_rdoc_class(full_name: "Jekyll::SeoTag", methods: 1)
+    drop = build_rdoc_class(full_name: "Jekyll::SeoTag::Drop", methods: 1)
+    plugin = build_rdoc_class(full_name: "Jekyll::Plugin", methods: 1)
+    liquid = build_rdoc_module(full_name: "Liquid", description: "Prevent bundler errors")
+    liquid_tag = build_rdoc_class(full_name: "Liquid::Tag")
+    unrelated = build_rdoc_class(full_name: "Unrelated", methods: 1)
+    nest_class(namespace, seo_tag)
+    nest_class(seo_tag, drop)
+    nest_class(liquid, liquid_tag)
+
+    dir = generate_from_store(
+      [namespace, seo_tag, drop, plugin, liquid, liquid_tag, unrelated],
+      markdown_namespaces: ["Jekyll::SeoTag", "Jekyll::Plugin"]
+    )
+    entries = index_entries(dir)
+
+    assert_false File.exist?(File.join(dir, "Jekyll.md"))
+    assert_true File.exist?(File.join(dir, "Jekyll/SeoTag.md"))
+    assert_true File.exist?(File.join(dir, "Jekyll/SeoTag/Drop.md"))
+    assert_true File.exist?(File.join(dir, "Jekyll/Plugin.md"))
+    assert_false File.exist?(File.join(dir, "Liquid.md"))
+    assert_false File.exist?(File.join(dir, "Liquid/Tag.md"))
+    assert_false File.exist?(File.join(dir, "Unrelated.md"))
+    assert_includes entries, ["Jekyll::SeoTag", "Class", "Jekyll/SeoTag.md"]
+    assert_includes entries, ["Jekyll::SeoTag::Drop", "Class", "Jekyll/SeoTag/Drop.md"]
+    assert_includes entries, ["Jekyll::Plugin", "Class", "Jekyll/Plugin.md"]
+    refute(entries.any? { |name, _type, _path| ["Jekyll", "Liquid", "Liquid::Tag", "Unrelated"].include?(name) })
+  end
+
+  def test_generate_treats_empty_generator_options_as_unfiltered
+    klass = build_rdoc_class(full_name: "EmptyOptions", methods: 1)
+    dir = stable_tmpdir("empty-generator-options")
+    options = generator_options(op_dir: dir)
+    options.generator_options = {}
+    generator = RDoc::Generator::Markdown.new(rdoc_store(classes: [klass]), options)
+
+    generator.generate
+
+    assert_true File.exist?(File.join(dir, "EmptyOptions.md"))
+    assert_includes index_entries(dir), ["EmptyOptions", "Class", "EmptyOptions.md"]
+  end
+
+  def test_generate_keeps_described_namespace_without_api_descendants
     namespace = build_rdoc_module(full_name: "Liquid", description: "Prevent bundler errors")
     child = build_rdoc_class(full_name: "Liquid::Tag")
     nest_class(namespace, child)
 
     dir = generate_from_store([namespace, child])
 
-    assert_false File.exist?(File.join(dir, "Liquid.md"))
-    assert_false File.exist?(File.join(dir, "Liquid/Tag.md"))
-    assert_predicate index_entries(dir), :empty?
+    assert_true File.exist?(File.join(dir, "Liquid.md"))
+    assert_true File.exist?(File.join(dir, "Liquid/Tag.md"))
+    assert_includes index_entries(dir), ["Liquid", "Module", "Liquid.md"]
+    assert_includes index_entries(dir), ["Liquid::Tag", "Class", "Liquid/Tag.md"]
   end
 
-  def test_generate_skips_empty_child_declaration_under_empty_namespace_module
+  def test_generate_keeps_empty_child_declaration_under_empty_namespace_module
     namespace = build_rdoc_module(full_name: "Ocean")
     child = build_rdoc_class(full_name: "Ocean::Salmon")
     nest_class(namespace, child)
 
     dir = generate_from_store([namespace, child])
 
-    assert_false File.exist?(File.join(dir, "Ocean.md"))
-    assert_false File.exist?(File.join(dir, "Ocean/Salmon.md"))
-    assert_predicate index_entries(dir), :empty?
+    assert_true File.exist?(File.join(dir, "Ocean.md"))
+    assert_true File.exist?(File.join(dir, "Ocean/Salmon.md"))
+    assert_includes index_entries(dir), ["Ocean", "Module", "Ocean.md"]
+    assert_includes index_entries(dir), ["Ocean::Salmon", "Class", "Ocean/Salmon.md"]
   end
 
-  def test_generate_skips_empty_child_declaration_under_membered_namespace
+  def test_generate_keeps_empty_child_declaration_under_membered_namespace
     namespace = build_rdoc_module(full_name: "Liquid", description: "Real namespace", methods: 1)
     child = build_rdoc_class(full_name: "Liquid::Tag")
     nest_class(namespace, child)
@@ -284,9 +386,9 @@ class TestClassDocs < Minitest::Test
     dir = generate_from_store([namespace, child])
 
     assert_true File.exist?(File.join(dir, "Liquid.md"))
-    assert_false File.exist?(File.join(dir, "Liquid/Tag.md"))
+    assert_true File.exist?(File.join(dir, "Liquid/Tag.md"))
     assert_includes index_entries(dir), ["Liquid", "Module", "Liquid.md"]
-    refute_includes index_entries(dir), ["Liquid::Tag", "Class", "Liquid/Tag.md"]
+    assert_includes index_entries(dir), ["Liquid::Tag", "Class", "Liquid/Tag.md"]
   end
 
   def test_generate_keeps_described_namespace_when_empty_child_has_documented_child
@@ -299,10 +401,10 @@ class TestClassDocs < Minitest::Test
     dir = generate_from_store([namespace, child, grandchild])
 
     assert_true File.exist?(File.join(dir, "Liquid.md"))
-    assert_false File.exist?(File.join(dir, "Liquid/Tag.md"))
+    assert_true File.exist?(File.join(dir, "Liquid/Tag.md"))
     assert_true File.exist?(File.join(dir, "Liquid/Tag/Block.md"))
     assert_includes index_entries(dir), ["Liquid", "Module", "Liquid.md"]
-    refute_includes index_entries(dir), ["Liquid::Tag", "Class", "Liquid/Tag.md"]
+    assert_includes index_entries(dir), ["Liquid::Tag", "Class", "Liquid/Tag.md"]
     assert_includes index_entries(dir), ["Liquid::Tag::Block", "Class", "Liquid/Tag/Block.md"]
   end
 
@@ -316,10 +418,10 @@ class TestClassDocs < Minitest::Test
     dir = generate_from_store([namespace, empty_child, documented_child])
 
     assert_true File.exist?(File.join(dir, "Liquid.md"))
-    assert_false File.exist?(File.join(dir, "Liquid/Tag.md"))
+    assert_true File.exist?(File.join(dir, "Liquid/Tag.md"))
     assert_true File.exist?(File.join(dir, "Liquid/Drop.md"))
     assert_includes index_entries(dir), ["Liquid", "Module", "Liquid.md"]
-    refute_includes index_entries(dir), ["Liquid::Tag", "Class", "Liquid/Tag.md"]
+    assert_includes index_entries(dir), ["Liquid::Tag", "Class", "Liquid/Tag.md"]
     assert_includes index_entries(dir), ["Liquid::Drop", "Class", "Liquid/Drop.md"]
   end
 
@@ -353,16 +455,16 @@ class TestClassDocs < Minitest::Test
     assert_includes index_entries(dir), ["Useful::Nested", "Module", "Useful/Nested.md"]
   end
 
-  def test_generate_skips_described_namespace_with_only_description_module_descendant
+  def test_generate_keeps_described_namespace_with_only_description_module_descendant
     namespace = build_rdoc_module(full_name: "Useful", description: "Useful namespace")
     nested = build_rdoc_module(full_name: "Useful::Nested", description: "Nested module")
     nest_module(namespace, nested)
 
     dir = generate_from_store([namespace, nested])
 
-    assert_false File.exist?(File.join(dir, "Useful.md"))
+    assert_true File.exist?(File.join(dir, "Useful.md"))
     assert_true File.exist?(File.join(dir, "Useful/Nested.md"))
-    refute_includes index_entries(dir), ["Useful", "Module", "Useful.md"]
+    assert_includes index_entries(dir), ["Useful", "Module", "Useful.md"]
     assert_includes index_entries(dir), ["Useful::Nested", "Module", "Useful/Nested.md"]
   end
 

--- a/test/test_class_docs.rb
+++ b/test/test_class_docs.rb
@@ -17,17 +17,15 @@ class TestClassDocs < Minitest::Test
   cover "RDoc::Generator::Markdown#emit_csv_index"
   cover "RDoc::Generator::Markdown#generate"
   cover "RDoc::Generator::Markdown#legacy_paths_for"
-  cover "RDoc::Generator::Markdown#markdown_namespace_included?"
-  cover "RDoc::Generator::Markdown#markdown_namespaces"
   cover "RDoc::Generator::Markdown#normalized_full_name"
   cover "RDoc::Generator::Markdown#output_path_for"
   cover "RDoc::Generator::Markdown#setup"
   cover "RDoc::Generator::Markdown#synthetic_full_name?"
 
-  def generate_from_store(classes, pages: nil, dir: stable_tmpdir("generate-from-store"), root: nil, markdown_namespaces: nil)
+  def generate_from_store(classes, pages: nil, dir: stable_tmpdir("generate-from-store"), root: nil)
     generator = RDoc::Generator::Markdown.new(
       rdoc_store(classes: classes, pages: pages),
-      generator_options(op_dir: dir, root: root, markdown_namespaces: markdown_namespaces)
+      generator_options(op_dir: dir, root: root)
     )
     generator.generate
     dir
@@ -306,50 +304,6 @@ class TestClassDocs < Minitest::Test
     assert_true File.exist?(File.join(dir, "Jekyll/SeoTag.md"))
     assert_includes index_entries(dir), ["Jekyll", "Module", "Jekyll.md"]
     assert_includes index_entries(dir), ["Jekyll::SeoTag", "Module", "Jekyll/SeoTag.md"]
-  end
-
-  def test_generate_filters_to_explicit_markdown_namespaces
-    namespace = build_rdoc_module(full_name: "Jekyll")
-    seo_tag = build_rdoc_class(full_name: "Jekyll::SeoTag", methods: 1)
-    drop = build_rdoc_class(full_name: "Jekyll::SeoTag::Drop", methods: 1)
-    plugin = build_rdoc_class(full_name: "Jekyll::Plugin", methods: 1)
-    liquid = build_rdoc_module(full_name: "Liquid", description: "Prevent bundler errors")
-    liquid_tag = build_rdoc_class(full_name: "Liquid::Tag")
-    unrelated = build_rdoc_class(full_name: "Unrelated", methods: 1)
-    nest_class(namespace, seo_tag)
-    nest_class(seo_tag, drop)
-    nest_class(liquid, liquid_tag)
-
-    dir = generate_from_store(
-      [namespace, seo_tag, drop, plugin, liquid, liquid_tag, unrelated],
-      markdown_namespaces: ["Jekyll::SeoTag", "Jekyll::Plugin"]
-    )
-    entries = index_entries(dir)
-
-    assert_false File.exist?(File.join(dir, "Jekyll.md"))
-    assert_true File.exist?(File.join(dir, "Jekyll/SeoTag.md"))
-    assert_true File.exist?(File.join(dir, "Jekyll/SeoTag/Drop.md"))
-    assert_true File.exist?(File.join(dir, "Jekyll/Plugin.md"))
-    assert_false File.exist?(File.join(dir, "Liquid.md"))
-    assert_false File.exist?(File.join(dir, "Liquid/Tag.md"))
-    assert_false File.exist?(File.join(dir, "Unrelated.md"))
-    assert_includes entries, ["Jekyll::SeoTag", "Class", "Jekyll/SeoTag.md"]
-    assert_includes entries, ["Jekyll::SeoTag::Drop", "Class", "Jekyll/SeoTag/Drop.md"]
-    assert_includes entries, ["Jekyll::Plugin", "Class", "Jekyll/Plugin.md"]
-    refute(entries.any? { |name, _type, _path| ["Jekyll", "Liquid", "Liquid::Tag", "Unrelated"].include?(name) })
-  end
-
-  def test_generate_treats_empty_generator_options_as_unfiltered
-    klass = build_rdoc_class(full_name: "EmptyOptions", methods: 1)
-    dir = stable_tmpdir("empty-generator-options")
-    options = generator_options(op_dir: dir)
-    options.generator_options = {}
-    generator = RDoc::Generator::Markdown.new(rdoc_store(classes: [klass]), options)
-
-    generator.generate
-
-    assert_true File.exist?(File.join(dir, "EmptyOptions.md"))
-    assert_includes index_entries(dir), ["EmptyOptions", "Class", "EmptyOptions.md"]
   end
 
   def test_generate_keeps_described_namespace_without_api_descendants

--- a/test/test_class_docs.rb
+++ b/test/test_class_docs.rb
@@ -628,6 +628,21 @@ class TestClassDocs < Minitest::Test
     ], entries.select { |_name, type, _path| type == "Attribute" }
   end
 
+  def test_generate_rejects_non_string_output_directory_before_writing
+    stringified_dir = File.join(stable_tmpdir("invalid-output-stringified"), "stringified")
+    invalid_output = Object.new
+    invalid_output.define_singleton_method(:to_s) { stringified_dir }
+    options = generator_options(op_dir: stable_tmpdir("invalid-output"))
+    options.op_dir = invalid_output
+    klass = build_rdoc_class(full_name: "InvalidOutput", methods: 1)
+
+    generator = RDoc::Generator::Markdown.new(rdoc_store(classes: [klass]), options)
+    error = assert_raises(TypeError) { generator.generate }
+
+    assert_includes error.message, "RDoc markdown output directory must be a String"
+    assert_false File.exist?(stringified_dir)
+  end
+
   def test_generate_prints_debug_messages_when_debug_is_enabled
     klass = build_rdoc_class(full_name: "Debug::Thing", description: "Doc")
     dir = stable_tmpdir("debug-output")

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -137,11 +137,51 @@ class TestGenerator < Minitest::Test
     refute_includes bird_doc, "Arguments: `direction, velocity`"
   end
 
-  def test_generator_writes_nested_leaf_classes_to_nested_paths
+  def test_generator_omits_nodoc_and_invisible_code_objects
+    source = File.join(stable_tmpdir("visibility-source"), "visibility_example.rb")
+    File.write(source, <<~RUBY)
+      class Visible
+        def public_method; end
+        def hidden_method; end # :nodoc:
+
+        private
+
+        def private_method; end
+      end
+
+      class HiddenClass # :nodoc:
+        def leaked_method; end
+      end
+
+      module HiddenModule # :nodoc:
+      end
+    RUBY
+
+    dir = run_generator(source, "visibility test title")
+
+    visible_doc = File.read(File.join(dir, "Visible.md"))
+    entries = CSV.parse(File.read(File.join(dir, "index.csv")), headers: true).map do |row|
+      [row["name"], row["type"], row["path"]]
+    end
+
+    assert_true File.exist?(File.join(dir, "Visible.md"))
+    assert_false File.exist?(File.join(dir, "HiddenClass.md"))
+    assert_false File.exist?(File.join(dir, "HiddenModule.md"))
+    assert_includes visible_doc, "#### `public_method()`"
+    refute_includes visible_doc, "hidden_method"
+    refute_includes visible_doc, "private_method"
+    assert_includes entries, ["Visible", "Class", "Visible.md"]
+    assert_includes entries, ["Visible.public_method", "Method", "Visible.md#method-i-public_method"]
+    refute(entries.any? { |name, _type, _path| name.include?("Hidden") })
+    refute(entries.any? { |name, _type, _path| name.include?("hidden_method") })
+    refute(entries.any? { |name, _type, _path| name.include?("private_method") })
+  end
+
+  def test_generator_writes_nested_namespaces_to_nested_paths
     dir = run_generator(File.join(__dir__, "data/namespaced_example.rb"), "namespaced test title")
 
-    assert_false File.exist?(File.join(dir, "Ocean.md"))
-    assert_false File.exist?(File.join(dir, "Ocean/Deep.md"))
+    assert File.exist?(File.join(dir, "Ocean.md"))
+    assert File.exist?(File.join(dir, "Ocean/Deep.md"))
     assert File.exist?(File.join(dir, "Ocean/Deep/Salmon.md"))
   end
 end

--- a/test/test_path_helpers.rb
+++ b/test/test_path_helpers.rb
@@ -63,11 +63,11 @@ class TestPathHelpers < Minitest::Test
     assert_nil markdown_generator.classes
   end
 
-  def test_turn_to_path_writes_nested_leaf_classes_to_nested_paths
+  def test_turn_to_path_writes_nested_namespaces_to_nested_paths
     dir = generate_docs(files: File.join(__dir__, "data/namespaced_example.rb"), title: "namespaced test title")
 
-    assert_false File.exist?(File.join(dir, "Ocean.md"))
-    assert_false File.exist?(File.join(dir, "Ocean/Deep.md"))
+    assert File.exist?(File.join(dir, "Ocean.md"))
+    assert File.exist?(File.join(dir, "Ocean/Deep.md"))
     assert File.exist?(File.join(dir, "Ocean/Deep/Salmon.md"))
   end
 


### PR DESCRIPTION
Fail before generation when RDoc supplies a non-string output directory so invalid options cannot be stringified into repo-root folders.

Add regression coverage that proves invalid output directories do not write their stringified paths.

Inline class/module selection on rdoc implementation (rdoc relies on .visible?)