### PR TITLE
Markdown unknown tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- Add `markdown_unknown_tags` RDoc option to configure reverse_markdown unknown tag handling
+
 ### Changed
 - Fail before generation when RDoc supplies a non-string output directory
 - Markdown template will only include visible classes/module/methods, same as rdoc does with HTML templates

--- a/README.md
+++ b/README.md
@@ -33,6 +33,22 @@ Run following command in directory with ruby source code:
 
 This will produce a tree of markdown documents and search index in `/doc` folder. Every class in library will have it's own markdown file.
 
+### Unknown HTML tags
+rdoc-markdown uses `reverse_markdown` to convert RDoc's HTML fragments to Markdown. You can configure how unknown HTML tags are handled with:
+
+```sh
+rdoc --format=markdown --markdown-unknown-tags=raise
+```
+
+Accepted values are `pass_through`, `drop`, `bypass`, and `raise`. The default is `pass_through`, which matches `reverse_markdown`'s default behavior.
+
+The same setting can be stored in RDoc's `.rdoc_options` file:
+
+```yaml
+---
+markdown_unknown_tags: :raise
+```
+
 ## Note on index.csv file
 This gem emits index of all markdown files in a index.csv file.
 

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -8,48 +8,6 @@ require "csv"
 require "cgi"
 require "optparse"
 
-# Adds rdoc-markdown generator configuration to RDoc's option object.
-module RDocMarkdownOptions
-  # Initializes markdown generator options alongside RDoc's built-in options.
-  #
-  # @return [void]
-  def init_ivars
-    super
-    @markdown_unknown_tags = :pass_through
-  end
-
-  # Loads markdown generator options from serialized RDoc options.
-  #
-  # @param map [Hash] Serialized RDoc options.
-  #
-  # @return [void]
-  def init_with(map)
-    super
-    value = map["markdown_unknown_tags"]
-    @markdown_unknown_tags = value unless value.nil?
-  end
-
-  # Applies markdown generator options from a loaded .rdoc_options hash.
-  #
-  # @param map [Hash] Loaded RDoc options.
-  #
-  # @return [void]
-  def override(map)
-    super
-    @markdown_unknown_tags = map["markdown_unknown_tags"] if map.key?("markdown_unknown_tags")
-  end
-end
-
-# RDoc configuration extended with markdown generator options.
-class RDoc::Options
-  prepend RDocMarkdownOptions
-
-  # Controls how reverse_markdown handles unknown HTML tags.
-  #
-  # @return [Symbol]
-  attr_accessor :markdown_unknown_tags
-end
-
 # Generates Markdown output and a CSV search index from an RDoc store.
 class RDoc::Generator::Markdown
   RDoc::RDoc.add_generator self
@@ -59,6 +17,37 @@ class RDoc::Generator::Markdown
 
   # Supported reverse_markdown unknown-tag modes.
   MARKDOWN_UNKNOWN_TAGS = %i[pass_through drop bypass raise].freeze
+
+  # Adds rdoc-markdown generator configuration to RDoc's option object.
+  module OptionsExtension
+    # Initializes markdown generator options alongside RDoc's built-in options.
+    #
+    # @return [void]
+    def init_ivars
+      super
+      @markdown_unknown_tags = :pass_through
+    end
+
+    # Loads markdown generator options from serialized RDoc options.
+    #
+    # @param map [Psych::Coder] Serialized RDoc options.
+    #
+    # @return [void]
+    def init_with(map)
+      super
+      @markdown_unknown_tags = map["markdown_unknown_tags"] if map.map.key?("markdown_unknown_tags")
+    end
+
+    # Applies markdown generator options from a loaded .rdoc_options hash.
+    #
+    # @param map [Hash] Loaded RDoc options.
+    #
+    # @return [void]
+    def override(map)
+      super
+      @markdown_unknown_tags = map.fetch("markdown_unknown_tags") if map.key?("markdown_unknown_tags")
+    end
+  end
 
   # Registers markdown generator-specific RDoc options.
   #
@@ -831,4 +820,14 @@ class RDoc::Generator::Markdown
 
     @root_path_segment = Pathname.new(@options.root || ".").basename
   end
+end
+
+# RDoc configuration extended with markdown generator options.
+class RDoc::Options
+  prepend RDoc::Generator::Markdown::OptionsExtension
+
+  # Controls how reverse_markdown handles unknown HTML tags.
+  #
+  # @return [Symbol]
+  attr_accessor :markdown_unknown_tags
 end

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -6,6 +6,49 @@ require "erb"
 require "reverse_markdown"
 require "csv"
 require "cgi"
+require "optparse"
+
+# Adds rdoc-markdown generator configuration to RDoc's option object.
+module RDocMarkdownOptions
+  # Initializes markdown generator options alongside RDoc's built-in options.
+  #
+  # @return [void]
+  def init_ivars
+    super
+    @markdown_unknown_tags = :pass_through
+  end
+
+  # Loads markdown generator options from serialized RDoc options.
+  #
+  # @param map [Hash] Serialized RDoc options.
+  #
+  # @return [void]
+  def init_with(map)
+    super
+    value = map["markdown_unknown_tags"]
+    @markdown_unknown_tags = value unless value.nil?
+  end
+
+  # Applies markdown generator options from a loaded .rdoc_options hash.
+  #
+  # @param map [Hash] Loaded RDoc options.
+  #
+  # @return [void]
+  def override(map)
+    super
+    @markdown_unknown_tags = map["markdown_unknown_tags"] if map.key?("markdown_unknown_tags")
+  end
+end
+
+# RDoc configuration extended with markdown generator options.
+class RDoc::Options
+  prepend RDocMarkdownOptions
+
+  # Controls how reverse_markdown handles unknown HTML tags.
+  #
+  # @return [Symbol]
+  attr_accessor :markdown_unknown_tags
+end
 
 # Generates Markdown output and a CSV search index from an RDoc store.
 class RDoc::Generator::Markdown
@@ -13,6 +56,33 @@ class RDoc::Generator::Markdown
 
   # Directory containing ERB templates.
   TEMPLATE_DIR = File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "templates"))
+
+  # Supported reverse_markdown unknown-tag modes.
+  MARKDOWN_UNKNOWN_TAGS = %i[pass_through drop bypass raise].freeze
+
+  # Registers markdown generator-specific RDoc options.
+  #
+  # @param rdoc_options [RDoc::Options] RDoc options object.
+  #
+  # @return [void]
+  def self.setup_options(rdoc_options)
+    rdoc_options.option_parser.on("--markdown-unknown-tags=MODE") do |value|
+      rdoc_options.markdown_unknown_tags = value.to_sym
+    end
+  end
+
+  # Validates the configured reverse_markdown unknown-tag mode.
+  #
+  # @param value [Symbol] Unknown-tag mode.
+  #
+  # @return [Symbol] Validated unknown-tag mode.
+  def self.validate_markdown_unknown_tags(value)
+    return value if MARKDOWN_UNKNOWN_TAGS.include?(value)
+
+    expected = MARKDOWN_UNKNOWN_TAGS.map { |mode| ":#{mode}" }.join(", ")
+    raise OptionParser::InvalidArgument,
+      "invalid markdown_unknown_tags: #{value.inspect} (expected one of: #{expected})"
+  end
 
   # Source store for generated content.
   #
@@ -50,6 +120,7 @@ class RDoc::Generator::Markdown
   def initialize(store, rdoc_options)
     @store = store
     @options = rdoc_options
+    @markdown_unknown_tags = self.class.validate_markdown_unknown_tags(rdoc_options.markdown_unknown_tags)
 
     @base_dir = Pathname.pwd
   end
@@ -252,7 +323,7 @@ class RDoc::Generator::Markdown
 
     html = normalize_rdoc_pre_blocks(input)
 
-    md = ReverseMarkdown.convert(html, github_flavored: true).dup
+    md = ReverseMarkdown.convert(html, github_flavored: true, unknown_tags: @markdown_unknown_tags).dup
 
     # Flatten headings whose visible text is wrapped in a self-link.
     md.gsub!(/^(#+)\s\[([^\]]+)\]\((?:#[^)]+)\)$/) { "#{Regexp.last_match(1)} #{Regexp.last_match(2)}" }

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -55,7 +55,10 @@ class RDoc::Generator::Markdown
   #
   # @return [void]
   def self.setup_options(rdoc_options)
-    rdoc_options.option_parser.on("--markdown-unknown-tags=MODE") do |value|
+    rdoc_options.option_parser.on(
+      "--markdown-unknown-tags=MODE",
+      "How to handle unknown HTML tags: #{MARKDOWN_UNKNOWN_TAGS.join(", ")}."
+    ) do |value|
       rdoc_options.markdown_unknown_tags = value.to_sym
     end
   end

--- a/test/test_markdown_helpers.rb
+++ b/test/test_markdown_helpers.rb
@@ -7,6 +7,9 @@ require "rdoc/rdoc"
 require "rdoc/markdown"
 
 class TestMarkdownHelpers < Minitest::Test
+  cover "RDoc::Generator::Markdown.setup_options"
+  cover "RDoc::Generator::Markdown.validate_markdown_unknown_tags"
+  cover "RDoc::Generator::Markdown#initialize"
   cover "RDoc::Generator::Markdown#markdownify"
   cover "RDoc::Generator::Markdown#describe"
   cover "RDoc::Generator::Markdown#debug"
@@ -22,11 +25,14 @@ class TestMarkdownHelpers < Minitest::Test
   cover "RDoc::Generator::Markdown#definition_list_line?"
   cover "RDoc::Generator::Markdown#normalize_rdoc_pre_blocks"
 
-  def generate_markdown(classes: [], pages: [], root: nil)
+  def generate_markdown(classes: [], pages: [], root: nil, markdown_unknown_tags: :pass_through)
     dir = stable_tmpdir("generated-markdown")
+    options = generator_options(op_dir: dir, root: root)
+    options.markdown_unknown_tags = markdown_unknown_tags
+
     RDoc::Generator::Markdown.new(
       rdoc_store(classes: classes, pages: pages),
-      generator_options(op_dir: dir, root: root)
+      options
     ).generate
     dir
   end
@@ -34,6 +40,12 @@ class TestMarkdownHelpers < Minitest::Test
   def read_generated(path, classes: [], pages: [], root: nil)
     dir = generate_markdown(classes: classes, pages: pages, root: root)
     File.read(File.join(dir, path))
+  end
+
+  def raw_html_page(relative_name:, html:)
+    rdoc_page(relative_name: relative_name, comment: "placeholder").tap do |page|
+      page.define_singleton_method(:description) { html }
+    end
   end
 
   def test_pages_are_markdownified_with_headings_links_and_definition_lists
@@ -90,6 +102,93 @@ class TestMarkdownHelpers < Minitest::Test
 
       assert_equal "# Topic\n", markdown
     end
+  end
+
+  def test_markdown_unknown_tags_defaults_to_pass_through
+    page = raw_html_page(
+      relative_name: "unknown-tags.rdoc",
+      html: "<p>before</p><custom>text <strong>bold</strong></custom><p>after</p>"
+    )
+
+    markdown = read_generated("unknown-tags_rdoc.md", pages: [page])
+
+    assert_includes markdown, "before"
+    assert_includes markdown, "<custom>text <strong>bold</strong></custom>"
+    assert_includes markdown, "after"
+  end
+
+  def test_markdown_unknown_tags_can_bypass_tags
+    page = raw_html_page(
+      relative_name: "bypass-tags.rdoc",
+      html: "<p>before</p><custom>text <strong>bold</strong></custom><p>after</p>"
+    )
+
+    markdown = File.read(File.join(generate_markdown(pages: [page], markdown_unknown_tags: :bypass), "bypass-tags_rdoc.md"))
+
+    assert_includes markdown, "before"
+    assert_includes markdown, "text **bold**"
+    assert_includes markdown, "after"
+    refute_includes markdown, "<custom>"
+  end
+
+  def test_markdown_unknown_tags_can_drop_tags_and_content
+    page = raw_html_page(
+      relative_name: "drop-tags.rdoc",
+      html: "<p>before</p><custom>text <strong>bold</strong></custom><p>after</p>"
+    )
+
+    markdown = File.read(File.join(generate_markdown(pages: [page], markdown_unknown_tags: :drop), "drop-tags_rdoc.md"))
+
+    assert_includes markdown, "before"
+    assert_includes markdown, "after"
+    refute_includes markdown, "text"
+    refute_includes markdown, "<custom>"
+  end
+
+  def test_markdown_unknown_tags_can_raise
+    page = raw_html_page(
+      relative_name: "raise-tags.rdoc",
+      html: "<p>before</p><custom>text</custom><p>after</p>"
+    )
+
+    assert_raises(ReverseMarkdown::UnknownTagError) do
+      generate_markdown(pages: [page], markdown_unknown_tags: :raise)
+    end
+  end
+
+  def test_markdown_unknown_tags_rejects_invalid_values
+    options = generator_options(op_dir: stable_tmpdir("invalid-unknown-tags"))
+    options.markdown_unknown_tags = :explode
+
+    error = assert_raises(OptionParser::InvalidArgument) do
+      RDoc::Generator::Markdown.new(rdoc_store, options)
+    end
+
+    assert_includes error.message, "invalid markdown_unknown_tags: :explode"
+    assert_includes error.message, "expected one of: :pass_through, :drop, :bypass, :raise"
+  end
+
+  def test_markdown_unknown_tags_can_be_set_by_cli_option
+    options = RDoc::Options.new.parse(%w[--format=markdown --markdown-unknown-tags=drop])
+
+    assert_equal :drop, options.markdown_unknown_tags
+  end
+
+  def test_markdown_unknown_tags_loads_from_rdoc_options_hash
+    options = RDoc::Options.new("markdown_unknown_tags" => :bypass)
+
+    assert_equal :bypass, options.markdown_unknown_tags
+  end
+
+  def test_markdown_unknown_tags_loads_from_serialized_rdoc_options
+    RDoc.load_yaml
+
+    options = YAML.safe_load(
+      "--- !ruby/object:RDoc::Options\nencoding: UTF-8\nstatic_path: []\nrdoc_include: []\nmarkdown_unknown_tags: :drop\n",
+      permitted_classes: [RDoc::Options, Symbol]
+    )
+
+    assert_equal :drop, options.markdown_unknown_tags
   end
 
   def test_multiple_rdoc_heading_levels_are_normalized

--- a/test/test_markdown_helpers.rb
+++ b/test/test_markdown_helpers.rb
@@ -179,6 +179,8 @@ class TestMarkdownHelpers < Minitest::Test
     options = RDoc::Options.new.parse(%w[--format=markdown --markdown-unknown-tags=drop])
 
     assert_equal :drop, options.markdown_unknown_tags
+    assert_includes options.option_parser.help, "--markdown-unknown-tags=MODE"
+    assert_includes options.option_parser.help, "pass_through, drop, bypass, raise"
   end
 
   def test_markdown_unknown_tags_loads_from_rdoc_options_hash

--- a/test/test_markdown_helpers.rb
+++ b/test/test_markdown_helpers.rb
@@ -7,6 +7,8 @@ require "rdoc/rdoc"
 require "rdoc/markdown"
 
 class TestMarkdownHelpers < Minitest::Test
+  DEFAULT_MARKDOWN_UNKNOWN_TAGS = Object.new.freeze
+
   cover "RDoc::Generator::Markdown.setup_options"
   cover "RDoc::Generator::Markdown.validate_markdown_unknown_tags"
   cover "RDoc::Generator::Markdown#initialize"
@@ -18,6 +20,9 @@ class TestMarkdownHelpers < Minitest::Test
   cover "RDoc::Generator::Markdown#section_description"
   cover "RDoc::Generator::Markdown#finalize_markdown"
   cover "RDoc::Generator::Markdown#normalize_internal_links"
+  cover "RDoc::Generator::Markdown::OptionsExtension#init_ivars"
+  cover "RDoc::Generator::Markdown::OptionsExtension#init_with"
+  cover "RDoc::Generator::Markdown::OptionsExtension#override"
   cover "RDoc::Generator::Markdown#resolve_output_path"
   cover "RDoc::Generator::Markdown#shift_headings"
   cover "RDoc::Generator::Markdown#normalize_definition_list_code_blocks"
@@ -25,10 +30,10 @@ class TestMarkdownHelpers < Minitest::Test
   cover "RDoc::Generator::Markdown#definition_list_line?"
   cover "RDoc::Generator::Markdown#normalize_rdoc_pre_blocks"
 
-  def generate_markdown(classes: [], pages: [], root: nil, markdown_unknown_tags: :pass_through)
+  def generate_markdown(classes: [], pages: [], root: nil, markdown_unknown_tags: DEFAULT_MARKDOWN_UNKNOWN_TAGS)
     dir = stable_tmpdir("generated-markdown")
     options = generator_options(op_dir: dir, root: root)
-    options.markdown_unknown_tags = markdown_unknown_tags
+    options.markdown_unknown_tags = markdown_unknown_tags unless markdown_unknown_tags.equal?(DEFAULT_MARKDOWN_UNKNOWN_TAGS)
 
     RDoc::Generator::Markdown.new(
       rdoc_store(classes: classes, pages: pages),
@@ -105,6 +110,8 @@ class TestMarkdownHelpers < Minitest::Test
   end
 
   def test_markdown_unknown_tags_defaults_to_pass_through
+    assert_equal :pass_through, RDoc::Options.new.markdown_unknown_tags
+
     page = raw_html_page(
       relative_name: "unknown-tags.rdoc",
       html: "<p>before</p><custom>text <strong>bold</strong></custom><p>after</p>"
@@ -175,9 +182,16 @@ class TestMarkdownHelpers < Minitest::Test
   end
 
   def test_markdown_unknown_tags_loads_from_rdoc_options_hash
-    options = RDoc::Options.new("markdown_unknown_tags" => :bypass)
+    options = RDoc::Options.new("markdown_unknown_tags" => :bypass, "visibility" => :private)
 
     assert_equal :bypass, options.markdown_unknown_tags
+    assert_equal :private, options.visibility
+  end
+
+  def test_markdown_unknown_tags_rdoc_options_hash_keeps_default_when_key_is_absent
+    options = RDoc::Options.new({})
+
+    assert_equal :pass_through, options.markdown_unknown_tags
   end
 
   def test_markdown_unknown_tags_loads_from_serialized_rdoc_options
@@ -189,6 +203,33 @@ class TestMarkdownHelpers < Minitest::Test
     )
 
     assert_equal :drop, options.markdown_unknown_tags
+    assert_equal Encoding::UTF_8, options.encoding
+    assert_false options.quiet
+  end
+
+  def test_markdown_unknown_tags_serialized_rdoc_options_keep_default_when_key_is_absent
+    RDoc.load_yaml
+
+    options = YAML.safe_load(
+      "--- !ruby/object:RDoc::Options\nencoding: UTF-8\nstatic_path: []\nrdoc_include: []\n",
+      permitted_classes: [RDoc::Options, Symbol]
+    )
+
+    assert_equal :pass_through, options.markdown_unknown_tags
+  end
+
+  def test_markdown_unknown_tags_rejects_nil_from_serialized_rdoc_options
+    RDoc.load_yaml
+    options = YAML.safe_load(
+      "--- !ruby/object:RDoc::Options\nencoding: UTF-8\nstatic_path: []\nrdoc_include: []\nmarkdown_unknown_tags:\n",
+      permitted_classes: [RDoc::Options, Symbol]
+    )
+
+    error = assert_raises(OptionParser::InvalidArgument) do
+      RDoc::Generator::Markdown.new(rdoc_store, options)
+    end
+
+    assert_includes error.message, "invalid markdown_unknown_tags: nil"
   end
 
   def test_multiple_rdoc_heading_levels_are_normalized


### PR DESCRIPTION
I want to be able to control how html to markdown conversion works with this gem. This PR introduces a configurable attribute that will be passed to ReverseMarkdown gem