### PR TITLE
rbs integration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     rdoc-markdown (0.8.0)
       csv
       erb
+      rbs
       rdoc
       reverse_markdown
 
@@ -112,6 +113,10 @@ GEM
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rainbow (3.1.1)
     rake (13.4.2)
+    rbs (4.0.2)
+      logger
+      prism (>= 1.6.0)
+      tsort
     rdiscount (2.2.7.4)
     rdoc (7.2.0)
       erb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     rdoc-markdown (0.8.0)
       csv
       erb
-      rbs
       rdoc
       reverse_markdown
 
@@ -198,6 +197,7 @@ DEPENDENCIES
   mutant-minitest
   mutex_m
   rake (~> 13.0)
+  rbs
   rdiscount (~> 2.0)
   rdoc-markdown!
   simplecov (~> 0.22)

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -3,11 +3,15 @@
 gem "rdoc"
 
 require "erb"
-require "rbs"
 require "reverse_markdown"
 require "csv"
 require "cgi"
 require "optparse"
+
+begin
+  require "rbs"
+rescue LoadError
+end
 
 # Generates Markdown output and a CSV search index from an RDoc store.
 class RDoc::Generator::Markdown
@@ -809,6 +813,8 @@ class RDoc::Generator::Markdown
   #
   # @return [Hash{Array => String}] Method signature lookup keyed by class and method.
   def build_rbs_method_signatures(files)
+    return {} unless defined?(RBS::Parser)
+
     files.each_with_object({}) do |file, signatures|
       next unless File.extname(file) == ".rbs"
 

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -8,14 +8,11 @@ require "csv"
 require "cgi"
 require "optparse"
 
-begin
-  require "rbs"
-rescue LoadError
-end
-
 # Generates Markdown output and a CSV search index from an RDoc store.
 class RDoc::Generator::Markdown
   RDoc::RDoc.add_generator self
+
+  require_relative "markdown/rbs_signature_index"
 
   # Directory containing ERB templates.
   TEMPLATE_DIR = File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "templates"))
@@ -404,11 +401,7 @@ class RDoc::Generator::Markdown
   #
   # @return [String, nil] RBS method type string when available.
   def rbs_method_signature(method)
-    @rbs_method_signatures[rbs_method_signature_key(
-      class_name: method.parent.full_name,
-      singleton: method.singleton,
-      method_name: method.name
-    )]
+    @rbs_method_signatures.signature_for(method)
   end
 
   # Merges RDoc parameter names into a type-only signature.
@@ -807,90 +800,6 @@ class RDoc::Generator::Markdown
     klass.method_list.any? || klass.constants.any? || klass.attributes.any?
   end
 
-  # Builds a lookup of RBS method signatures for files included in this RDoc run.
-  #
-  # @param files [Array<String>] Input files passed to RDoc.
-  #
-  # @return [Hash{Array => String}] Method signature lookup keyed by class and method.
-  def build_rbs_method_signatures(files)
-    return {} unless defined?(RBS::Parser)
-
-    files.each_with_object({}) do |file, signatures|
-      next unless File.extname(file) == ".rbs"
-
-      _buffer, _directives, declarations = RBS::Parser.parse_signature(File.read(file))
-      declarations.each do |declaration|
-        collect_rbs_method_signatures(declaration, signatures: signatures)
-      end
-    end
-  end
-
-  # Adds method signatures from an RBS declaration or member.
-  #
-  # @param declaration [Object] RBS declaration or member.
-  # @param signatures [Hash{Array => String}] Signature lookup being populated.
-  # @param outer_name [String, nil] Containing class or module name.
-  #
-  # @return [void]
-  def collect_rbs_method_signatures(declaration, signatures:, outer_name: nil)
-    case declaration
-    when RBS::AST::Declarations::Class, RBS::AST::Declarations::Module
-      declaration_name = declaration.name
-      full_name = outer_name ? "#{outer_name}::#{declaration_name}" : declaration_name
-      declaration.members.each do |member|
-        collect_rbs_method_signatures(member, signatures: signatures, outer_name: full_name)
-      end
-    when RBS::AST::Members::MethodDefinition
-      collect_rbs_method_definition_signature(declaration, signatures: signatures, outer_name: outer_name)
-    end
-  end
-
-  # Adds a single RBS method definition signature.
-  #
-  # @param method_definition [RBS::AST::Members::MethodDefinition] RBS method definition.
-  # @param signatures [Hash{Array => String}] Signature lookup being populated.
-  # @param outer_name [String] Containing class or module name.
-  #
-  # @return [void]
-  def collect_rbs_method_definition_signature(method_definition, signatures:, outer_name:)
-    method_name = method_definition.name.to_s
-    method_type = method_definition.overloads.last.method_type
-
-    signatures[rbs_method_signature_key(
-      class_name: outer_name,
-      singleton: method_definition.singleton?,
-      method_name: method_name
-    )] = method_type.to_s
-
-    return unless method_name == "initialize" && !method_definition.singleton?
-
-    signatures[rbs_method_signature_key(
-      class_name: outer_name,
-      singleton: true,
-      method_name: "new"
-    )] = method_type.to_s
-  end
-
-  # Normalizes RBS names to match RDoc full names.
-  #
-  # @param name [Object] RBS name-like object.
-  #
-  # @return [String] RDoc-style class or module name.
-  def normalized_rbs_name(name)
-    name.to_s.delete_prefix("::")
-  end
-
-  # Builds the RBS signature lookup key for a method.
-  #
-  # @param class_name [String] RDoc-style class or module name.
-  # @param singleton [Boolean] Whether the method is a singleton method.
-  # @param method_name [String] Method name.
-  #
-  # @return [Array<String, Boolean, String>] Signature lookup key.
-  def rbs_method_signature_key(class_name:, singleton:, method_name:)
-    [normalized_rbs_name(class_name), singleton, method_name]
-  end
-
   # Checks whether a name appears to contain duplicated root namespaces.
   #
   # @param full_name [String] Full RDoc object name.
@@ -915,7 +824,7 @@ class RDoc::Generator::Markdown
     @class_docs_by_object_id = @class_docs.to_h { |doc| [doc.fetch(:klass).object_id, doc] }
     @classes = @class_docs.map { |doc| doc.fetch(:klass) }
     @pages = @store.all_files.select(&:text?).select(&:display?).sort_by(&:base_name)
-    @rbs_method_signatures = build_rbs_method_signatures(Array(@options.files))
+    @rbs_method_signatures = RbsSignatureIndex.build(Array(@options.files))
 
     @known_output_paths = Set.new
     @class_docs.each do |doc|

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -386,22 +386,13 @@ class RDoc::Generator::Markdown
   #
   # @return [String] Normalized method signature.
   def method_signature(method)
-    signature = rbs_method_signature(method) || method.param_seq
+    signature = @rbs_method_signatures.signature_for(method) || method.param_seq
     return "()" unless signature.match?(/\S/)
 
     signature = signature.gsub("->", " -> ")
     signature = signature.gsub(/\s+/, " ").strip
     signature = " #{signature}" if signature.start_with?("->")
     merge_method_signature_arguments(signature, method.params)
-  end
-
-  # Looks up a method signature parsed from matching RBS input files.
-  #
-  # @param method [RDoc::AnyMethod] Method object to render.
-  #
-  # @return [String, nil] RBS method type string when available.
-  def rbs_method_signature(method)
-    @rbs_method_signatures.signature_for(method)
   end
 
   # Merges RDoc parameter names into a type-only signature.

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -395,6 +395,13 @@ class RDoc::Generator::Markdown
     merge_method_signature_arguments(signature, method.params)
   end
 
+  # Checks whether this documentation set has parsed RBS signatures.
+  #
+  # @return [Boolean] True when type signatures are available.
+  def types_available?
+    @rbs_method_signatures.any?
+  end
+
   # Merges RDoc parameter names into a type-only signature.
   #
   # @param signature [String] Method signature from RDoc call sequence.

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -3,6 +3,7 @@
 gem "rdoc"
 
 require "erb"
+require "rbs"
 require "reverse_markdown"
 require "csv"
 require "cgi"
@@ -384,13 +385,26 @@ class RDoc::Generator::Markdown
   #
   # @return [String] Normalized method signature.
   def method_signature(method)
-    signature = method.param_seq
+    signature = rbs_method_signature(method) || method.param_seq
     return "()" unless signature.match?(/\S/)
 
     signature = signature.gsub("->", " -> ")
     signature = signature.gsub(/\s+/, " ").strip
     signature = " #{signature}" if signature.start_with?("->")
     merge_method_signature_arguments(signature, method.params)
+  end
+
+  # Looks up a method signature parsed from matching RBS input files.
+  #
+  # @param method [RDoc::AnyMethod] Method object to render.
+  #
+  # @return [String, nil] RBS method type string when available.
+  def rbs_method_signature(method)
+    @rbs_method_signatures[rbs_method_signature_key(
+      class_name: method.parent.full_name,
+      singleton: method.singleton,
+      method_name: method.name
+    )]
   end
 
   # Merges RDoc parameter names into a type-only signature.
@@ -789,6 +803,88 @@ class RDoc::Generator::Markdown
     klass.method_list.any? || klass.constants.any? || klass.attributes.any?
   end
 
+  # Builds a lookup of RBS method signatures for files included in this RDoc run.
+  #
+  # @param files [Array<String>] Input files passed to RDoc.
+  #
+  # @return [Hash{Array => String}] Method signature lookup keyed by class and method.
+  def build_rbs_method_signatures(files)
+    files.each_with_object({}) do |file, signatures|
+      next unless File.extname(file) == ".rbs"
+
+      _buffer, _directives, declarations = RBS::Parser.parse_signature(File.read(file))
+      declarations.each do |declaration|
+        collect_rbs_method_signatures(declaration, signatures: signatures)
+      end
+    end
+  end
+
+  # Adds method signatures from an RBS declaration or member.
+  #
+  # @param declaration [Object] RBS declaration or member.
+  # @param signatures [Hash{Array => String}] Signature lookup being populated.
+  # @param outer_name [String, nil] Containing class or module name.
+  #
+  # @return [void]
+  def collect_rbs_method_signatures(declaration, signatures:, outer_name: nil)
+    case declaration
+    when RBS::AST::Declarations::Class, RBS::AST::Declarations::Module
+      declaration_name = declaration.name
+      full_name = outer_name ? "#{outer_name}::#{declaration_name}" : declaration_name
+      declaration.members.each do |member|
+        collect_rbs_method_signatures(member, signatures: signatures, outer_name: full_name)
+      end
+    when RBS::AST::Members::MethodDefinition
+      collect_rbs_method_definition_signature(declaration, signatures: signatures, outer_name: outer_name)
+    end
+  end
+
+  # Adds a single RBS method definition signature.
+  #
+  # @param method_definition [RBS::AST::Members::MethodDefinition] RBS method definition.
+  # @param signatures [Hash{Array => String}] Signature lookup being populated.
+  # @param outer_name [String] Containing class or module name.
+  #
+  # @return [void]
+  def collect_rbs_method_definition_signature(method_definition, signatures:, outer_name:)
+    method_name = method_definition.name.to_s
+    method_type = method_definition.overloads.last.method_type
+
+    signatures[rbs_method_signature_key(
+      class_name: outer_name,
+      singleton: method_definition.singleton?,
+      method_name: method_name
+    )] = method_type.to_s
+
+    return unless method_name == "initialize" && !method_definition.singleton?
+
+    signatures[rbs_method_signature_key(
+      class_name: outer_name,
+      singleton: true,
+      method_name: "new"
+    )] = method_type.to_s
+  end
+
+  # Normalizes RBS names to match RDoc full names.
+  #
+  # @param name [Object] RBS name-like object.
+  #
+  # @return [String] RDoc-style class or module name.
+  def normalized_rbs_name(name)
+    name.to_s.delete_prefix("::")
+  end
+
+  # Builds the RBS signature lookup key for a method.
+  #
+  # @param class_name [String] RDoc-style class or module name.
+  # @param singleton [Boolean] Whether the method is a singleton method.
+  # @param method_name [String] Method name.
+  #
+  # @return [Array<String, Boolean, String>] Signature lookup key.
+  def rbs_method_signature_key(class_name:, singleton:, method_name:)
+    [normalized_rbs_name(class_name), singleton, method_name]
+  end
+
   # Checks whether a name appears to contain duplicated root namespaces.
   #
   # @param full_name [String] Full RDoc object name.
@@ -813,6 +909,7 @@ class RDoc::Generator::Markdown
     @class_docs_by_object_id = @class_docs.to_h { |doc| [doc.fetch(:klass).object_id, doc] }
     @classes = @class_docs.map { |doc| doc.fetch(:klass) }
     @pages = @store.all_files.select(&:text?).select(&:display?).sort_by(&:base_name)
+    @rbs_method_signatures = build_rbs_method_signatures(Array(@options.files))
 
     @known_output_paths = Set.new
     @class_docs.each do |doc|

--- a/lib/rdoc/generator/markdown/rbs_signature_index.rb
+++ b/lib/rdoc/generator/markdown/rbs_signature_index.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# Optional lookup of method signatures parsed from RBS files.
+class RDoc::Generator::Markdown::RbsSignatureIndex
+  # Builds a signature index from RBS files included in an RDoc run.
+  #
+  # @param files [Array<String>] Input files passed to RDoc.
+  #
+  # @return [RDoc::Generator::Markdown::RbsSignatureIndex] Signature index.
+  def self.build(files)
+    rbs_files = files.select { |file| File.extname(file) == ".rbs" }
+    new(signatures_from(rbs_files))
+  end
+
+  # Builds signatures by reusing RBS's own RDoc parser.
+  #
+  # @param files [Array<String>] RBS files to parse.
+  #
+  # @return [Hash{Array => String}] Signature lookup keyed by class and method.
+  def self.signatures_from(files)
+    files.each_with_object({}) do |file, signatures|
+      parsed_classes(file).each do |klass|
+        klass.method_list.each do |method|
+          add_method_signature(signatures, klass: klass, method: method)
+        end
+      end
+    end
+  end
+
+  # Parses one RBS file into RDoc class/module objects.
+  #
+  # @param file [String] RBS file path.
+  #
+  # @return [Array<RDoc::Context>] Classes and modules parsed from RBS.
+  def self.parsed_classes(file)
+    store = RDoc::Store.new(RDoc::Options.new)
+    top_level = store.add_file(file)
+    parser = RDoc::Parser.for(top_level, File.read(file), store.options, nil)
+    parser.scan
+    store.all_classes_and_modules
+  end
+
+  # Adds one RBS-parsed method signature to the lookup.
+  #
+  # @param signatures [Hash{Array => String}] Signature lookup being populated.
+  # @param klass [RDoc::Context] Method owner.
+  # @param method [RDoc::AnyMethod] Method parsed by the RBS plugin.
+  #
+  # @return [void]
+  def self.add_method_signature(signatures, klass:, method:)
+    signatures[signature_key(klass.full_name, method.singleton, method.name)] = method.param_seq
+
+    return unless method.name == "initialize" && !method.singleton
+
+    signatures[signature_key(klass.full_name, true, "new")] = method.param_seq
+  end
+
+  # Builds the signature lookup key for a method.
+  #
+  # @param class_name [String] RDoc-style class or module name.
+  # @param singleton [Boolean] Whether the method is a singleton method.
+  # @param method_name [String] Method name.
+  #
+  # @return [Array<String, Boolean, String>] Signature lookup key.
+  def self.signature_key(class_name, singleton, method_name)
+    [class_name, singleton, method_name]
+  end
+
+  # @param signatures [Hash{Array => String}] Signature lookup.
+  def initialize(signatures)
+    @signatures = signatures
+  end
+
+  # Looks up the RBS signature for an RDoc method.
+  #
+  # @param method [RDoc::AnyMethod] Method object to render.
+  #
+  # @return [String, nil] RBS method type string when available.
+  def signature_for(method)
+    @signatures[self.class.signature_key(method.parent.full_name, method.singleton, method.name)]
+  end
+end

--- a/lib/rdoc/generator/markdown/rbs_signature_index.rb
+++ b/lib/rdoc/generator/markdown/rbs_signature_index.rb
@@ -48,22 +48,11 @@ class RDoc::Generator::Markdown::RbsSignatureIndex
   #
   # @return [void]
   def self.add_method_signature(signatures, klass:, method:)
-    signatures[signature_key(klass.full_name, method.singleton, method.name)] = method.param_seq
+    signatures[[klass.full_name, method.singleton, method.name]] = method.param_seq
 
     return unless method.name == "initialize" && !method.singleton
 
-    signatures[signature_key(klass.full_name, true, "new")] = method.param_seq
-  end
-
-  # Builds the signature lookup key for a method.
-  #
-  # @param class_name [String] RDoc-style class or module name.
-  # @param singleton [Boolean] Whether the method is a singleton method.
-  # @param method_name [String] Method name.
-  #
-  # @return [Array<String, Boolean, String>] Signature lookup key.
-  def self.signature_key(class_name, singleton, method_name)
-    [class_name, singleton, method_name]
+    signatures[[klass.full_name, true, "new"]] = method.param_seq
   end
 
   # @param signatures [Hash{Array => String}] Signature lookup.
@@ -77,6 +66,6 @@ class RDoc::Generator::Markdown::RbsSignatureIndex
   #
   # @return [String, nil] RBS method type string when available.
   def signature_for(method)
-    @signatures[self.class.signature_key(method.parent.full_name, method.singleton, method.name)]
+    @signatures[[method.parent.full_name, method.singleton, method.name]]
   end
 end

--- a/lib/rdoc/generator/markdown/rbs_signature_index.rb
+++ b/lib/rdoc/generator/markdown/rbs_signature_index.rb
@@ -68,4 +68,11 @@ class RDoc::Generator::Markdown::RbsSignatureIndex
   def signature_for(method)
     @signatures[[method.parent.full_name, method.singleton, method.name]]
   end
+
+  # Checks whether any RBS signatures were parsed.
+  #
+  # @return [Boolean] True when type signatures are available.
+  def any?
+    @signatures.any?
+  end
 end

--- a/lib/templates/classfile.md.erb
+++ b/lib/templates/classfile.md.erb
@@ -1,5 +1,9 @@
 # <%= klass.type.capitalize %> <%= display_name(klass) %>
 <%= anchor(klass.aref.strip) %>
+<%- if types_available? -%>
+
+_Type signatures available._
+<%- end -%>
 <%- class_description = describe(klass) -%>
 <%- unless class_description.empty? -%>
 

--- a/rdoc-markdown.gemspec
+++ b/rdoc-markdown.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "csv"
   spec.add_dependency "erb"
   spec.add_dependency "rdoc"
+  spec.add_dependency "rbs"
   spec.add_dependency "reverse_markdown"
 
   spec.add_development_dependency "bundler", ">= 2.0"

--- a/rdoc-markdown.gemspec
+++ b/rdoc-markdown.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "csv"
   spec.add_dependency "erb"
   spec.add_dependency "rdoc"
-  spec.add_dependency "rbs"
   spec.add_dependency "reverse_markdown"
 
   spec.add_development_dependency "bundler", ">= 2.0"
@@ -42,6 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "minitest-strict", "~> 1.0"
   spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rbs"
   spec.add_development_dependency "rdiscount", "~> 2.0"
   spec.add_development_dependency "simplecov", "~> 0.22"
 end

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -7,18 +7,27 @@ require "rdoc/markdown"
 require "rdiscount"
 
 class TestGenerator < Minitest::Test
+  cover "RDoc::Generator::Markdown#build_rbs_method_signatures"
+  cover "RDoc::Generator::Markdown#collect_rbs_method_definition_signature"
+  cover "RDoc::Generator::Markdown#collect_rbs_method_signatures"
+  cover "RDoc::Generator::Markdown#method_signature"
+  cover "RDoc::Generator::Markdown#normalized_rbs_name"
+  cover "RDoc::Generator::Markdown#rbs_method_signature"
+  cover "RDoc::Generator::Markdown#rbs_method_signature_key"
+  cover "RDoc::Generator::Markdown#setup"
+
   def source_file
     File.join(File.dirname(__FILE__), "data/example.rb")
   end
 
-  def run_generator(file, title)
+  def run_generator(files, title)
     dir = File.join(stable_tmpdir("generator-output"), "out")
 
     options = RDoc::Options.new
     options.setup_generator "markdown"
 
     options.verbosity = 0
-    options.files = [file]
+    options.files = Array(files)
     options.op_dir = dir
     options.title = title
 
@@ -135,6 +144,72 @@ class TestGenerator < Minitest::Test
 
     assert_includes bird_doc, "#### `fly(direction: string, velocity: number) -> bool`"
     refute_includes bird_doc, "Arguments: `direction, velocity`"
+  end
+
+  def test_generator_uses_rbs_signatures_for_ruby_methods
+    source_dir = stable_tmpdir("rbs-signature-source")
+    ruby_file = File.join(source_dir, "bird.rb")
+    rbs_file = File.join(source_dir, "bird.rbs")
+
+    File.write(ruby_file, <<~RUBY)
+      module Aviary
+        class Bird
+          def initialize(name)
+          end
+
+          def fly(direction, velocity)
+          end
+
+          def build(name)
+          end
+
+          def self.build(name)
+          end
+        end
+      end
+
+      class AbsoluteBird
+        def chirp(sound)
+        end
+      end
+
+      class PlainBird
+        def chirp(sound)
+        end
+      end
+    RUBY
+
+    File.write(rbs_file, <<~RBS)
+      module Aviary
+        class Bird
+          def initialize: (String name) -> void
+          def fly: (String direction, Integer velocity) -> bool
+          def build: (Symbol name) -> String
+          def self.build: (String name) -> Bird
+          def self.initialize: () -> singleton(Bird)
+        end
+      end
+
+      class ::AbsoluteBird
+        def chirp: (String sound) -> String
+      end
+    RBS
+
+    dir = run_generator([ruby_file, rbs_file], "rbs signature title")
+    bird_doc = File.read(File.join(dir, "Aviary/Bird.md"))
+    absolute_bird_doc = File.read(File.join(dir, "AbsoluteBird.md"))
+    plain_bird_doc = File.read(File.join(dir, "PlainBird.md"))
+
+    assert_includes bird_doc, "#### `new(String name) -> void`"
+    assert_includes bird_doc, "#### `fly(String direction, Integer velocity) -> bool`"
+    assert_includes bird_doc, "#### `build(Symbol name) -> String`"
+    assert_includes bird_doc, "#### `build(String name) -> Bird`"
+    assert_includes absolute_bird_doc, "#### `chirp(String sound) -> String`"
+    assert_includes plain_bird_doc, "#### `chirp(sound)`"
+    refute_includes bird_doc, "#### `new() -> singleton(Bird)`"
+    refute_includes bird_doc, "#### `fly(direction, velocity)`"
+    refute_includes bird_doc, "#### `build(name)`"
+    refute_includes plain_bird_doc, "#### `chirp(String sound) -> String`"
   end
 
   def test_generator_omits_nodoc_and_invisible_code_objects

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -7,13 +7,8 @@ require "rdoc/markdown"
 require "rdiscount"
 
 class TestGenerator < Minitest::Test
-  cover "RDoc::Generator::Markdown#build_rbs_method_signatures"
-  cover "RDoc::Generator::Markdown#collect_rbs_method_definition_signature"
-  cover "RDoc::Generator::Markdown#collect_rbs_method_signatures"
   cover "RDoc::Generator::Markdown#method_signature"
-  cover "RDoc::Generator::Markdown#normalized_rbs_name"
   cover "RDoc::Generator::Markdown#rbs_method_signature"
-  cover "RDoc::Generator::Markdown#rbs_method_signature_key"
   cover "RDoc::Generator::Markdown#setup"
 
   def source_file
@@ -218,32 +213,6 @@ class TestGenerator < Minitest::Test
     refute_includes plain_bird_doc, "#### `chirp(String sound) -> String`"
   end
 
-  def test_generator_ignores_rbs_files_when_rbs_is_unavailable
-    source_dir = stable_tmpdir("rbs-unavailable-source")
-    rbs_file = File.join(source_dir, "bird.rbs")
-    File.write(rbs_file, <<~RBS)
-      class Bird
-        def fly: (String direction) -> bool
-      end
-    RBS
-
-    dir = File.join(stable_tmpdir("rbs-unavailable-output"), "out")
-    klass = build_rdoc_class(full_name: "Bird", description: "Bird docs")
-    klass.add_method(rdoc_method("fly", params: "(direction)"))
-
-    options = generator_options(op_dir: dir)
-    options.files = [rbs_file]
-
-    without_rbs_constant do
-      RDoc::Generator::Markdown.new(rdoc_store(classes: [klass], pages: []), options).generate
-    end
-
-    bird_doc = File.read(File.join(dir, "Bird.md"))
-
-    assert_includes bird_doc, "#### `fly(direction)`"
-    refute_includes bird_doc, "#### `fly(String direction) -> bool`"
-  end
-
   def test_generator_omits_nodoc_and_invisible_code_objects
     source = File.join(stable_tmpdir("visibility-source"), "visibility_example.rb")
     File.write(source, <<~RUBY)
@@ -290,12 +259,5 @@ class TestGenerator < Minitest::Test
     assert File.exist?(File.join(dir, "Ocean.md"))
     assert File.exist?(File.join(dir, "Ocean/Deep.md"))
     assert File.exist?(File.join(dir, "Ocean/Deep/Salmon.md"))
-  end
-
-  def without_rbs_constant
-    rbs = Object.send(:remove_const, :RBS) if Object.const_defined?(:RBS, false)
-    yield
-  ensure
-    Object.const_set(:RBS, rbs) if rbs
   end
 end

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -8,7 +8,6 @@ require "rdiscount"
 
 class TestGenerator < Minitest::Test
   cover "RDoc::Generator::Markdown#method_signature"
-  cover "RDoc::Generator::Markdown#rbs_method_signature"
   cover "RDoc::Generator::Markdown#setup"
 
   def source_file

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -9,6 +9,7 @@ require "rdiscount"
 class TestGenerator < Minitest::Test
   cover "RDoc::Generator::Markdown#method_signature"
   cover "RDoc::Generator::Markdown#setup"
+  cover "RDoc::Generator::Markdown#types_available?"
 
   def source_file
     File.join(File.dirname(__FILE__), "data/example.rb")
@@ -199,17 +200,19 @@ class TestGenerator < Minitest::Test
     plain_bird_doc = File.read(File.join(dir, "PlainBird.md"))
 
     assert_includes ruby_only_bird_doc, "#### `fly(direction, velocity)`"
-    refute_includes ruby_only_bird_doc, "#### `fly(String direction, Integer velocity) -> bool`"
+    refute_includes ruby_only_bird_doc, "_Type signatures available._"
+    assert_equal 1, bird_doc.scan("_Type signatures available._").count
     assert_includes bird_doc, "#### `new(String name) -> void`"
     assert_includes bird_doc, "#### `fly(String direction, Integer velocity) -> bool`"
     assert_includes bird_doc, "#### `build(Symbol name) -> String`"
     assert_includes bird_doc, "#### `build(String name) -> Bird`"
+    assert_includes absolute_bird_doc, "_Type signatures available._"
     assert_includes absolute_bird_doc, "#### `chirp(String sound) -> String`"
+    assert_includes plain_bird_doc, "_Type signatures available._"
     assert_includes plain_bird_doc, "#### `chirp(sound)`"
     refute_includes bird_doc, "#### `new() -> singleton(Bird)`"
     refute_includes bird_doc, "#### `fly(direction, velocity)`"
     refute_includes bird_doc, "#### `build(name)`"
-    refute_includes plain_bird_doc, "#### `chirp(String sound) -> String`"
   end
 
   def test_generator_omits_nodoc_and_invisible_code_objects

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -147,6 +147,8 @@ class TestGenerator < Minitest::Test
   end
 
   def test_generator_uses_rbs_signatures_for_ruby_methods
+    skip "rbs is not available" unless defined?(RBS::Parser)
+
     source_dir = stable_tmpdir("rbs-signature-source")
     ruby_file = File.join(source_dir, "bird.rb")
     rbs_file = File.join(source_dir, "bird.rbs")
@@ -195,11 +197,15 @@ class TestGenerator < Minitest::Test
       end
     RBS
 
+    ruby_only_dir = run_generator([ruby_file], "ruby signature title")
     dir = run_generator([ruby_file, rbs_file], "rbs signature title")
+    ruby_only_bird_doc = File.read(File.join(ruby_only_dir, "Aviary/Bird.md"))
     bird_doc = File.read(File.join(dir, "Aviary/Bird.md"))
     absolute_bird_doc = File.read(File.join(dir, "AbsoluteBird.md"))
     plain_bird_doc = File.read(File.join(dir, "PlainBird.md"))
 
+    assert_includes ruby_only_bird_doc, "#### `fly(direction, velocity)`"
+    refute_includes ruby_only_bird_doc, "#### `fly(String direction, Integer velocity) -> bool`"
     assert_includes bird_doc, "#### `new(String name) -> void`"
     assert_includes bird_doc, "#### `fly(String direction, Integer velocity) -> bool`"
     assert_includes bird_doc, "#### `build(Symbol name) -> String`"
@@ -210,6 +216,32 @@ class TestGenerator < Minitest::Test
     refute_includes bird_doc, "#### `fly(direction, velocity)`"
     refute_includes bird_doc, "#### `build(name)`"
     refute_includes plain_bird_doc, "#### `chirp(String sound) -> String`"
+  end
+
+  def test_generator_ignores_rbs_files_when_rbs_is_unavailable
+    source_dir = stable_tmpdir("rbs-unavailable-source")
+    rbs_file = File.join(source_dir, "bird.rbs")
+    File.write(rbs_file, <<~RBS)
+      class Bird
+        def fly: (String direction) -> bool
+      end
+    RBS
+
+    dir = File.join(stable_tmpdir("rbs-unavailable-output"), "out")
+    klass = build_rdoc_class(full_name: "Bird", description: "Bird docs")
+    klass.add_method(rdoc_method("fly", params: "(direction)"))
+
+    options = generator_options(op_dir: dir)
+    options.files = [rbs_file]
+
+    without_rbs_constant do
+      RDoc::Generator::Markdown.new(rdoc_store(classes: [klass], pages: []), options).generate
+    end
+
+    bird_doc = File.read(File.join(dir, "Bird.md"))
+
+    assert_includes bird_doc, "#### `fly(direction)`"
+    refute_includes bird_doc, "#### `fly(String direction) -> bool`"
   end
 
   def test_generator_omits_nodoc_and_invisible_code_objects
@@ -258,5 +290,12 @@ class TestGenerator < Minitest::Test
     assert File.exist?(File.join(dir, "Ocean.md"))
     assert File.exist?(File.join(dir, "Ocean/Deep.md"))
     assert File.exist?(File.join(dir, "Ocean/Deep/Salmon.md"))
+  end
+
+  def without_rbs_constant
+    rbs = Object.send(:remove_const, :RBS) if Object.const_defined?(:RBS, false)
+    yield
+  ensure
+    Object.const_set(:RBS, rbs) if rbs
   end
 end

--- a/test/test_rbs_signature_index.rb
+++ b/test/test_rbs_signature_index.rb
@@ -27,6 +27,7 @@ class TestRbsSignatureIndex < Minitest::Test
     index = RDoc::Generator::Markdown::RbsSignatureIndex.build(["bird.rb"])
 
     assert_nil index.signature_for(ruby_method(class_name: "Bird", method_name: "fly"))
+    assert_false index.any?
   end
 
   def test_build_returns_empty_index_when_rbs_gem_is_unavailable
@@ -78,6 +79,7 @@ class TestRbsSignatureIndex < Minitest::Test
 
     index = RDoc::Generator::Markdown::RbsSignatureIndex.build([file])
 
+    assert_true index.any?
     assert_equal "(String name) -> void", index.signature_for(ruby_method(
       class_name: "Aviary::Bird",
       method_name: "new",

--- a/test/test_rbs_signature_index.rb
+++ b/test/test_rbs_signature_index.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+require "open3"
+require "rbconfig"
+require "rdoc/markdown"
+
+class TestRbsSignatureIndex < Minitest::Test
+  cover "RDoc::Generator::Markdown::RbsSignatureIndex*"
+
+  def rbs_file(source)
+    path = File.join(stable_tmpdir("rbs-signature-index"), "bird.rbs")
+    File.write(path, source)
+    path
+  end
+
+  def ruby_method(class_name:, method_name:, singleton: false)
+    klass = build_rdoc_class(full_name: class_name, description: "docs")
+    method = rdoc_method(method_name, params: "(value)")
+    method.singleton = singleton
+    klass.add_method(method)
+    method
+  end
+
+  def test_build_returns_empty_index_without_rbs_files
+    index = RDoc::Generator::Markdown::RbsSignatureIndex.build(["bird.rb"])
+
+    assert_nil index.signature_for(ruby_method(class_name: "Bird", method_name: "fly"))
+  end
+
+  def test_build_returns_empty_index_when_rbs_gem_is_unavailable
+    file = rbs_file(<<~RBS)
+      class Bird
+        def fly: (String value) -> bool
+      end
+    RBS
+
+    output, status = run_without_rbs_gem(<<~'RUBY', file)
+      require "rdoc/rdoc"
+
+      class RDoc::Generator::Markdown
+      end
+
+      require "rdoc/generator/markdown/rbs_signature_index"
+
+      rbs_parser = RDoc::Parser.parsers.any? do |regexp, parser|
+        regexp.match?("bird.rbs") && parser.name == "RDoc::Parser::RBS"
+      end
+      raise "RBS parser should not be available" if rbs_parser
+
+      parent = Struct.new(:full_name).new("Bird")
+      method = Struct.new(:parent, :singleton, :name).new(parent, false, "fly")
+      signature = RDoc::Generator::Markdown::RbsSignatureIndex.build([ARGV.fetch(0)]).signature_for(method)
+
+      raise "unexpected signature: #{signature}" if signature
+    RUBY
+
+    assert_true status.success?, output
+  end
+
+  def test_build_indexes_rbs_signatures_from_rdoc_parser_output
+    file = rbs_file(<<~RBS)
+      module Aviary
+        class Bird
+          def initialize: (String name) -> void
+          def fly: (String direction, Integer velocity) -> bool
+          def build: (Symbol name) -> String
+          def self.build: (String name) -> Bird
+          def self.initialize: () -> singleton(Bird)
+        end
+      end
+
+      class ::AbsoluteBird
+        def chirp: (String sound) -> String
+      end
+    RBS
+
+    index = RDoc::Generator::Markdown::RbsSignatureIndex.build([file])
+
+    assert_equal "(String name) -> void", index.signature_for(ruby_method(
+      class_name: "Aviary::Bird",
+      method_name: "new",
+      singleton: true
+    ))
+    assert_equal "(String direction, Integer velocity) -> bool", index.signature_for(ruby_method(
+      class_name: "Aviary::Bird",
+      method_name: "fly"
+    ))
+    assert_equal "(Symbol name) -> String", index.signature_for(ruby_method(
+      class_name: "Aviary::Bird",
+      method_name: "build"
+    ))
+    assert_equal "(String name) -> Bird", index.signature_for(ruby_method(
+      class_name: "Aviary::Bird",
+      method_name: "build",
+      singleton: true
+    ))
+    assert_equal "(String sound) -> String", index.signature_for(ruby_method(
+      class_name: "AbsoluteBird",
+      method_name: "chirp"
+    ))
+    assert_nil index.signature_for(ruby_method(class_name: "PlainBird", method_name: "chirp"))
+  end
+
+  def run_without_rbs_gem(source, *arguments)
+    gem_home = stable_tmpdir("empty-gems")
+    rdoc_lib = File.join(Gem.loaded_specs.fetch("rdoc").full_gem_path, "lib")
+    env = {
+      "BUNDLE_BIN_PATH" => nil,
+      "BUNDLE_GEMFILE" => nil,
+      "BUNDLE_LOCKFILE" => nil,
+      "BUNDLER_SETUP" => nil,
+      "BUNDLER_VERSION" => nil,
+      "GEM_HOME" => gem_home,
+      "GEM_PATH" => gem_home,
+      "RUBYLIB" => nil,
+      "RUBYOPT" => ""
+    }
+    command = [
+      RbConfig.ruby,
+      "-I#{File.expand_path("../lib", __dir__)}",
+      "-I#{rdoc_lib}",
+      "-e",
+      source,
+      *arguments
+    ]
+    stdout, stderr, status = Open3.capture3(env, *command)
+
+    [stdout + stderr, status]
+  end
+end


### PR DESCRIPTION
Add optional RBS-aware method signature rendering to rdoc-markdown without making rbs a runtime dependency.

## Constraints & Preferences
- rdoc-markdown gem must not depend on rbs at runtime.
- If rbs is available/discovered, generator should take full advantage of RBS signatures.
- The consumer needs a way to understand if gem has types.
