### PR TITLE
handle duplicate method names

### DIFF
--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -178,7 +178,7 @@ class RDoc::Generator::Markdown
           csv << [
             "#{display_name(klass)}.#{method.name}",
             "Method",
-            "#{output_path_for(klass)}##{method.aref}"
+            "#{output_path_for(klass)}##{method_anchor(method)}"
           ]
         end
 
@@ -616,9 +616,49 @@ class RDoc::Generator::Markdown
   # @return [String] Anchor or relative Markdown link target.
   def method_link(method, current_class:)
     target_parent = method.parent
-    return "##{method.aref}" if target_parent == current_class
+    return "##{method_anchor(method)}" if target_parent == current_class
 
-    "#{output_path_for(target_parent)}##{method.aref}"
+    "#{output_path_for(target_parent)}##{method_anchor(method)}"
+  end
+
+  # Returns the generated Markdown anchor for a method.
+  #
+  # RDoc exposes overloaded constructor documentation as multiple displayable
+  # class methods named `new`, each with the same `method-c-new` aref.
+  #
+  # @param method [RDoc::AnyMethod] Method object to render or link to.
+  #
+  # @return [String] Unique Markdown anchor for this method.
+  def method_anchor(method)
+    @method_anchors_by_object_id.fetch(method.object_id, method.aref)
+  end
+
+  # Assigns unique method anchors within each generated class page.
+  #
+  # @return [Hash{Integer => String}] Method object id to unique anchor.
+  def build_method_anchors
+    @classes.each_with_object({}) do |klass, anchors|
+      counts = Hash.new(0)
+      used = Set.new
+
+      klass.method_list.select(&:display?).each do |method|
+        base_anchor = method.aref
+        counts[base_anchor] += 1
+        anchor = if counts[base_anchor] == 1
+          base_anchor
+        else
+          "#{base_anchor}-#{counts[base_anchor]}"
+        end
+
+        while used.include?(anchor)
+          counts[base_anchor] += 1
+          anchor = "#{base_anchor}-#{counts[base_anchor]}"
+        end
+
+        used << anchor
+        anchors[method.object_id] = anchor
+      end
+    end
   end
 
   # Removes RDoc's generated HTML tags from verbatim pre blocks.
@@ -823,6 +863,7 @@ class RDoc::Generator::Markdown
     @classes = @class_docs.map { |doc| doc.fetch(:klass) }
     @pages = @store.all_files.select(&:text?).select(&:display?).sort_by(&:base_name)
     @rbs_method_signatures = RbsSignatureIndex.build(Array(@options.files))
+    @method_anchors_by_object_id = build_method_anchors
 
     @known_output_paths = Set.new
     @class_docs.each do |doc|

--- a/lib/templates/classfile.md.erb
+++ b/lib/templates/classfile.md.erb
@@ -52,7 +52,7 @@ _Type signatures available._
 <% methods.each do |method| -%>
 
 #### `<%= method.name %><%= method_signature(method) %>`
-<%= anchor(method.aref) %>
+<%= anchor(method_anchor(method)) %>
 
 <%= method_description(method, current_class: klass) %>
 <% end -%>

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -141,6 +141,45 @@ class TestGenerator < Minitest::Test
     refute_includes bird_doc, "Arguments: `direction, velocity`"
   end
 
+  def test_generator_disambiguates_duplicate_rdoc_method_arefs
+    source = File.join(stable_tmpdir("duplicate-method-arefs"), "example.rb")
+    File.write(source, <<~RUBY)
+      class DuplicateNewExample
+        def self.new(*args, **options, &block)
+          super
+        end
+
+        def initialize(name)
+        end
+      end
+
+      class AliasThenNewExample
+        class << self
+          alias_method :create, :new
+          def new(name)
+          end
+        end
+
+        def initialize(name, extra = nil)
+        end
+      end
+    RUBY
+
+    dir = run_generator(source, "duplicate arefs")
+    duplicate_doc = File.read(File.join(dir, "DuplicateNewExample.md"))
+    alias_doc = File.read(File.join(dir, "AliasThenNewExample.md"))
+    index_rows = CSV.parse(File.read(File.join(dir, "index.csv")), headers: true).map do |row|
+      [row["name"], row["type"], row["path"]]
+    end
+
+    assert_equal 1, duplicate_doc.scan('<a id="method-c-new"></a>').count
+    assert_equal 1, duplicate_doc.scan('<a id="method-c-new-2"></a>').count
+    assert_includes alias_doc, "Alias for: [`new`](#method-c-new)"
+    assert_includes index_rows, ["DuplicateNewExample.new", "Method", "DuplicateNewExample.md#method-c-new"]
+    assert_includes index_rows, ["DuplicateNewExample.new", "Method", "DuplicateNewExample.md#method-c-new-2"]
+    assert_equal index_rows.uniq, index_rows
+  end
+
   def test_generator_uses_rbs_signatures_for_ruby_methods
     skip "rbs is not available" unless defined?(RBS::Parser)
 


### PR DESCRIPTION
RDoc creates duplicate displayable method objects when a class has both:
- an explicit class method named new
- an instance initialize, which RDoc exposes as class method new
That is exactly what happened in ActiveSupport:
- ActiveSupport::Deprecation::DeprecatedConstantProxy has def self.new(...) and def initialize(...)
- ActiveSupport::TimeZone has class-level def new(name) and instance def initialize(name, utc_offset = nil, tzinfo = nil)

Both RDoc method objects get the same anchor: method-c-new.

I also verified built-in RDoc darkfish emits duplicate id="method-c-new" anchors for a minimal reproduction, so the collision originates in RDoc’s model/rendering behavior.

## Problem

rdoc-markdown was using method.aref directly in both places:
- Markdown method anchors
- index.csv paths
So it faithfully passed through RDoc’s duplicate method-c-new values, producing exact duplicate rows.

## Fix
Changed rdoc-markdown to assign unique method anchors per class page:
- first duplicate keeps method-c-new
- next duplicate becomes method-c-new-2
- alias links and index.csv now use the resolved unique anchor