### PR TITLE
adding a better converter for code blocks

### DIFF
--- a/.yard-lint.yml
+++ b/.yard-lint.yml
@@ -13,7 +13,7 @@ AllValidators:
     - "spec/**/*"
     - "test/**/*"
     - "tmp/**/*"
-    - lib/rdoc/markdown/version.rb
+    - "lib/rdoc/markdown/version.rb"
 
   FailOnSeverity: error
   MinCoverage: 100.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- properly convert code block to markdown with language definition
+
 ### Fixed
 - Put generated anchors before heading lines so terminal markdown renderers parse headings correctly.
 

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -5,8 +5,8 @@ gem "rdoc"
 require "erb"
 require "reverse_markdown"
 require "csv"
-require "cgi"
 require "optparse"
+require_relative "markdown/rdoc_markdown_pre"
 
 # Generates Markdown output and a CSV search index from an RDoc store.
 class RDoc::Generator::Markdown
@@ -315,9 +315,7 @@ class RDoc::Generator::Markdown
     # - bypass - Ignore the unknown tag but try to convert its content
     # - raise - Raise an error to let you know
 
-    html = normalize_rdoc_pre_blocks(input)
-
-    md = ReverseMarkdown.convert(html, github_flavored: true, unknown_tags: @markdown_unknown_tags).dup
+    md = ReverseMarkdown.convert(input, github_flavored: true, unknown_tags: @markdown_unknown_tags).dup
 
     # Flatten headings whose visible text is wrapped in a self-link.
     md.gsub!(/^(#+)\s\[([^\]]+)\]\((?:#[^)]+)\)$/) { "#{Regexp.last_match(1)} #{Regexp.last_match(2)}" }
@@ -574,7 +572,7 @@ class RDoc::Generator::Markdown
   #
   # @return [String] Markdown with convertible blocks normalized.
   def normalize_definition_list_code_blocks(markdown)
-    markdown.gsub(/```\n(.+?)\n```/m) do
+    markdown.gsub(/```[^\n]*\n(.+?)\n```/m) do
       body = Regexp.last_match(1)
       converted = convert_definition_list_block(body)
       converted.nil? ? Regexp.last_match : converted
@@ -620,19 +618,6 @@ class RDoc::Generator::Markdown
     return "##{method.aref}" if target_parent == current_class
 
     "#{output_path_for(target_parent)}##{method.aref}"
-  end
-
-  # Removes RDoc's generated HTML tags from verbatim pre blocks.
-  #
-  # @param html [String] RDoc HTML fragment.
-  #
-  # @return [String] HTML fragment with normalized pre blocks.
-  def normalize_rdoc_pre_blocks(html)
-    html.gsub(%r{<pre\b[^>]*>(?:.+?)</pre>}m) do
-      raw = Regexp.last_match(0)
-      text = raw.gsub(/<[^>]+>/, "")
-      "<pre>#{CGI.unescapeHTML(text)}</pre>"
-    end
   end
 
   # Rewrites local Markdown links relative to the current output file.

--- a/lib/rdoc/generator/markdown/rbs_signature_index.rb
+++ b/lib/rdoc/generator/markdown/rbs_signature_index.rb
@@ -148,7 +148,11 @@ class RDoc::Generator::Markdown::RbsSignatureIndex
     Array(lines).select { |line| line&.match?(/\S/) }
   end
 
+  # Creates an immutable signature index.
+  #
   # @param signatures [Hash{Array => Array<String>}] Signature lookup.
+  #
+  # @return [void]
   def initialize(signatures)
     @signatures = signatures
   end

--- a/lib/rdoc/generator/markdown/rdoc_markdown_pre.rb
+++ b/lib/rdoc/generator/markdown/rdoc_markdown_pre.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Preserves simple <pre class="ruby"> language metadata emitted by RDoc.
+class ReverseMarkdown::Converters::RDocMarkdownPre < ReverseMarkdown::Converters::Pre
+  LANGUAGE_CLASS = /\A(?!highlight\z)[A-Za-z][A-Za-z0-9_+-]*\z/
+
+  def convert(node, *)
+    content = treat_children(rdoc_pre_node(node), {})
+    "\n```#{language(node)}\n" << content << "\n```\n"
+  end
+
+  private
+
+  def rdoc_pre_node(node)
+    Nokogiri::HTML.fragment("<pre>#{node.text}</pre>").at("pre")
+  end
+
+  def language(node)
+    node["class"].to_s[LANGUAGE_CLASS] || super
+  end
+end
+
+ReverseMarkdown::Converters.register :pre, ReverseMarkdown::Converters::RDocMarkdownPre.new

--- a/lib/rdoc/generator/markdown/rdoc_markdown_pre.rb
+++ b/lib/rdoc/generator/markdown/rdoc_markdown_pre.rb
@@ -2,19 +2,36 @@
 
 # Preserves simple <pre class="ruby"> language metadata emitted by RDoc.
 class ReverseMarkdown::Converters::RDocMarkdownPre < ReverseMarkdown::Converters::Pre
+  # Matches RDoc's plain language class names on pre blocks.
   LANGUAGE_CLASS = /\A(?!highlight\z)[A-Za-z][A-Za-z0-9_+-]*\z/
 
-  def convert(node, *)
+  # Converts an RDoc pre block into a GitHub-flavored Markdown fence.
+  #
+  # @param node [Nokogiri::XML::Node] RDoc pre node.
+  # @param _state [Hash] reverse_markdown converter state.
+  #
+  # @return [String] Markdown code fence.
+  def convert(node, _state = {})
     content = treat_children(rdoc_pre_node(node), {})
     "\n```#{language(node)}\n" << content << "\n```\n"
   end
 
   private
 
+  # Rebuilds a plain pre node from RDoc-highlighted text.
+  #
+  # @param node [Nokogiri::XML::Node] RDoc pre node.
+  #
+  # @return [Nokogiri::XML::Node] Plain pre node.
   def rdoc_pre_node(node)
     Nokogiri::HTML.fragment("<pre>#{node.text}</pre>").at("pre")
   end
 
+  # Extracts the Markdown fence language.
+  #
+  # @param node [Nokogiri::XML::Node] RDoc pre node.
+  #
+  # @return [String, nil] Language name, or nil when no language is known.
   def language(node)
     node["class"].to_s[LANGUAGE_CLASS] || super
   end

--- a/lib/rdoc/generator/markdown/rdoc_markdown_pre.rb
+++ b/lib/rdoc/generator/markdown/rdoc_markdown_pre.rb
@@ -11,7 +11,7 @@ class ReverseMarkdown::Converters::RDocMarkdownPre < ReverseMarkdown::Converters
   # @param _state [Hash] reverse_markdown converter state.
   #
   # @return [String] Markdown code fence.
-  def convert(node, _state = {})
+  def convert(node, _state)
     content = treat_children(rdoc_pre_node(node), {})
     "\n```#{language(node)}\n" << content << "\n```\n"
   end

--- a/lib/rdoc/markdown/version.rb
+++ b/lib/rdoc/markdown/version.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
+# @private
 module Rdoc
+  # @private
   module Markdown
+    # @private
     VERSION = "0.10.3"
   end
 end

--- a/mutant.yml
+++ b/mutant.yml
@@ -13,3 +13,4 @@ requires:
 matcher:
   subjects:
     - RDoc::Generator::Markdown*
+    - ReverseMarkdown::Converters::RDocMarkdownPre*

--- a/test/test_markdown_helpers.rb
+++ b/test/test_markdown_helpers.rb
@@ -28,7 +28,7 @@ class TestMarkdownHelpers < Minitest::Test
   cover "RDoc::Generator::Markdown#normalize_definition_list_code_blocks"
   cover "RDoc::Generator::Markdown#convert_definition_list_block"
   cover "RDoc::Generator::Markdown#definition_list_line?"
-  cover "RDoc::Generator::Markdown#normalize_rdoc_pre_blocks"
+  cover "ReverseMarkdown::Converters::RDocMarkdownPre*"
 
   def generate_markdown(classes: [], pages: [], root: nil, markdown_unknown_tags: DEFAULT_MARKDOWN_UNKNOWN_TAGS)
     dir = stable_tmpdir("generated-markdown")
@@ -107,6 +107,14 @@ class TestMarkdownHelpers < Minitest::Test
 
       assert_equal "# Topic\n", markdown
     end
+  end
+
+  def test_markdownify_uses_github_flavored_markdown
+    page = raw_html_page(relative_name: "github-flavored.rdoc", html: "<p><del>old</del></p>")
+
+    markdown = read_generated("github-flavored_rdoc.md", pages: [page])
+
+    assert_includes markdown, "~~old~~"
   end
 
   def test_markdown_unknown_tags_defaults_to_pass_through
@@ -256,12 +264,43 @@ class TestMarkdownHelpers < Minitest::Test
     refute_includes markdown, "<br />"
   end
 
+  def test_rdoc_ruby_pre_blocks_preserve_language_metadata
+    page = rdoc_page(relative_name: "ruby-block.rdoc", comment: "= Heading\n\n    require 'erb'\n    puts :ok\n")
+
+    markdown = read_generated("ruby-block_rdoc.md", pages: [page])
+
+    assert_includes markdown, "```ruby\nrequire 'erb'\nputs :ok\n```"
+  end
+
+  def test_pre_block_language_classes_are_preserved
+    page = raw_html_page(relative_name: "json-block.rdoc", html: "<pre class=\"json\">{&quot;ok&quot;: true}</pre>")
+    r_page = raw_html_page(relative_name: "r-block.rdoc", html: "<pre class=\"r\">1</pre>")
+
+    markdown = read_generated("json-block_rdoc.md", pages: [page])
+    r_markdown = read_generated("r-block_rdoc.md", pages: [r_page])
+
+    assert_includes markdown, "```json\n{\"ok\": true}\n```"
+    assert_includes r_markdown, "```r\n1\n```"
+  end
+
+  def test_pre_converter_uses_only_simple_language_classes
+    assert_equal "```r\nputs :ok\n```\n", ReverseMarkdown.convert("<pre class=\"r\">\nputs :ok\n</pre>", github_flavored: true)
+    assert_equal "```\nputs :ok\n```\n", ReverseMarkdown.convert("<pre class=\"highlight\">puts :ok</pre>", github_flavored: true)
+    assert_equal "```\nputs :ok\n```\n", ReverseMarkdown.convert("<pre class=\"1bad\">puts :ok</pre>", github_flavored: true)
+  end
+
+  def test_pre_converter_preserves_reverse_markdown_parent_highlight_language
+    markdown = ReverseMarkdown.convert("<div class=\"highlight-ruby\"><pre>puts :ok</pre></div>", github_flavored: true)
+
+    assert_includes markdown, "```ruby\nputs :ok\n```"
+  end
+
   def test_invalid_definition_list_blocks_remain_plain_text
     page = rdoc_page(relative_name: "invalid-definition.rdoc", comment: "= Heading\n\n  bird::\n  plain text\n")
 
     markdown = read_generated("invalid-definition_rdoc.md", pages: [page])
 
-    assert_includes markdown, "```\nbird::\nplain text\n```"
+    assert_includes markdown, "```ruby\nbird::\nplain text\n```"
     refute_includes markdown, "- plain text"
   end
 


### PR DESCRIPTION
ReverseMarkdown can't properly detect code block language, because he is expecting `<pre class="highlight-<lang>">...</pre>`. But what we usually get from ruby is `<pre class="<lang>">..</pre>`

I'm rewriting `pre` converter to handle that properly. 

I also understood, that we don't need `normalize_rdoc_pre_blocks` block at all here.