### PR TITLE
remove external namespaces from documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## Unreleased
 
+- Remove external namespaces from documentation
+
 ## 0.16.1
 
 - Fix copying Markdown pages when RDoc receives relative input paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## Unreleased
 
-- Remove external namespaces from documentation
+- Remove fabricated external namespaces and preserve exact class and module paths.
 
 ## 0.16.1
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ rake vendor:setup:rails
 bundle exec rake test
 ```
 
-The rails harness validates alias rendering, preserved code blocks, file/page links rewritten to markdown, and unique index entries.
+The rails harness validates alias rendering, preserved code blocks, file/page links rewritten to markdown, and omission of fabricated external namespaces.
 
 ### Generate vendored docs
 Use rake tasks to generate markdown output for vendored projects:

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ rake vendor:setup:rails
 bundle exec rake test
 ```
 
-The rails harness validates alias rendering, preserved code blocks, file/page links rewritten to markdown, and index stability (no synthetic nested class names).
+The rails harness validates alias rendering, preserved code blocks, file/page links rewritten to markdown, and unique index entries.
 
 ### Generate vendored docs
 Use rake tasks to generate markdown output for vendored projects:

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -771,6 +771,7 @@ class RDoc::Generator::Markdown
         klass = doc.fetch(:klass)
 
         doc.fetch(:score).positive? ||
+          klass.sections.any? { |section| section.title.to_s.match?(/\S/) } ||
           (klass.in_files.any? && !class_has_raw_members?(klass) && !synthetic_full_name?(klass.full_name))
       end
       .sort_by { |doc| doc.fetch(:display_name) }
@@ -806,7 +807,6 @@ class RDoc::Generator::Markdown
   # @return [Integer] Content score used to choose duplicate docs.
   def class_content_score(klass)
     score = class_member_count(klass)
-    score += klass.sections.count { |section| section.title }
     score += 1 unless klass.description.empty?
     score
   end

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -390,16 +390,19 @@ class RDoc::Generator::Markdown
   #
   # @param code_object [RDoc::CodeObject, RDoc::Context::Section] Object whose description is rendered.
   #
-  # @return [String, nil] HTML description, or nil for an empty section.
+  # @return [String] HTML description.
   def render_description(code_object)
-    return if RDoc::Context::Section === code_object && code_object.comments.empty?
-
-    formatter = code_object.formatter
+    section = RDoc::Context::Section === code_object
+    formatter = if section
+      code_object.parent.formatter.dup.tap { |copy| copy.code_object = code_object }
+    else
+      code_object.formatter
+    end
     formatter.extend(CrossrefExtension)
     begin
       formatter.markdown_cross_reference = RDoc::CrossReference.new(formatter.context)
       formatter.markdown_output_object_ids = @markdown_output_object_ids
-      code_object.description
+      section ? code_object.to_document.accept(formatter) : code_object.description
     ensure
       formatter.markdown_cross_reference = nil
     end
@@ -747,10 +750,7 @@ class RDoc::Generator::Markdown
 
     classes.select(&:display?).each do |klass|
       score = class_content_score(klass)
-      renderable = score.positive? ||
-        klass.sections.any? { |section| section.title.to_s.match?(/\S/) } ||
-        (klass.in_files.any? && !class_has_raw_members?(klass) && !synthetic_full_name?(klass.full_name))
-      next unless renderable
+      next unless class_renderable?(klass, score)
 
       display_name = normalized_full_name(klass.full_name)
       output_path = turn_to_path(display_name)
@@ -773,6 +773,21 @@ class RDoc::Generator::Markdown
 
     docs_by_name.values
       .sort_by { |doc| doc.fetch(:display_name) }
+  end
+
+  # Checks whether the class template has meaningful output for an object.
+  #
+  # @param klass [RDoc::Context] Class or module object.
+  # @param score [Integer] Visible content score used for duplicate ranking.
+  #
+  # @return [Boolean] True when the object should have a generated page.
+  def class_renderable?(klass, score)
+    score.positive? ||
+      klass.sections.any? { |section| section.title.to_s.match?(/\S/) || section.comments.any? } ||
+      (!synthetic_full_name?(klass.full_name) &&
+        ((klass.type == "class" && !klass.superclass.nil?) ||
+          klass.includes.any? ||
+          (klass.in_files.any? && !class_has_raw_members?(klass))))
   end
 
   # Collapses repeated namespace segments from synthetic vendored names.

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -771,7 +771,7 @@ class RDoc::Generator::Markdown
         klass = doc.fetch(:klass)
 
         doc.fetch(:score).positive? ||
-          (!class_has_raw_members?(klass) && !synthetic_full_name?(klass.full_name))
+          (klass.in_files.any? && !class_has_raw_members?(klass) && !synthetic_full_name?(klass.full_name))
       end
       .sort_by { |doc| doc.fetch(:display_name) }
   end
@@ -806,6 +806,7 @@ class RDoc::Generator::Markdown
   # @return [Integer] Content score used to choose duplicate docs.
   def class_content_score(klass)
     score = class_member_count(klass)
+    score += klass.sections.count { |section| section.title }
     score += 1 unless klass.description.empty?
     score
   end

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -746,9 +746,14 @@ class RDoc::Generator::Markdown
     docs_by_name = {}
 
     classes.select(&:display?).each do |klass|
+      score = class_content_score(klass)
+      renderable = score.positive? ||
+        klass.sections.any? { |section| section.title.to_s.match?(/\S/) } ||
+        (klass.in_files.any? && !class_has_raw_members?(klass) && !synthetic_full_name?(klass.full_name))
+      next unless renderable
+
       display_name = normalized_full_name(klass.full_name)
       output_path = turn_to_path(display_name)
-      score = class_content_score(klass)
 
       candidate = {
         klass: klass,
@@ -767,13 +772,6 @@ class RDoc::Generator::Markdown
     end
 
     docs_by_name.values
-      .select do |doc|
-        klass = doc.fetch(:klass)
-
-        doc.fetch(:score).positive? ||
-          klass.sections.any? { |section| section.title.to_s.match?(/\S/) } ||
-          (klass.in_files.any? && !class_has_raw_members?(klass) && !synthetic_full_name?(klass.full_name))
-      end
       .sort_by { |doc| doc.fetch(:display_name) }
   end
 

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -785,8 +785,7 @@ class RDoc::Generator::Markdown
     score.positive? ||
       klass.sections.any? { |section| section.title.to_s.match?(/\S/) || section.comments.any? } ||
       (!synthetic_full_name?(klass.full_name) &&
-        ((klass.type == "class" && !klass.superclass.nil?) ||
-          klass.includes.any? ||
+        (klass.includes.any? ||
           (klass.in_files.any? && !class_has_raw_members?(klass))))
   end
 

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -396,8 +396,9 @@ class RDoc::Generator::Markdown
       if section
         locale = options.locale
         documents = code_object.comments.map do |comment|
-          comment = RDoc::I18n::Text.new(comment).translate(locale) if locale
-          code_object.parse(comment)
+          comment = comment.dup
+          comment.text = RDoc::I18n::Text.new(comment).translate(locale) if locale
+          comment.parse
         end
         RDoc::Markup::Document.new(*documents).accept(formatter)
       else

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -752,7 +752,7 @@ class RDoc::Generator::Markdown
 
     @classes = @store.unique_classes_and_modules.select(&:display?).select do |klass|
       klass.in_files.any? ||
-        !klass.description.empty? ||
+        klass.documented? ||
         klass.includes.any? ||
         klass.method_list.any?(&:display?) ||
         klass.constants.any?(&:display?) ||

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -152,14 +152,14 @@ class RDoc::Generator::Markdown
 
       @classes.each do |klass|
         csv << [
-          display_name(klass),
+          klass.full_name,
           klass.type.capitalize,
           output_path_for(klass)
         ]
 
         klass.method_list.select(&:display?).each do |method|
           csv << [
-            "#{display_name(klass)}.#{method.name}",
+            "#{klass.full_name}.#{method.name}",
             "Method",
             "#{output_path_for(klass)}##{method.aref}"
           ]
@@ -171,7 +171,7 @@ class RDoc::Generator::Markdown
           .sort
           .each do |const|
             csv << [
-              "#{display_name(klass)}.#{const.name}",
+              "#{klass.full_name}.#{const.name}",
               "Constant",
               "#{output_path_for(klass)}##{const.name}"
             ]
@@ -183,7 +183,7 @@ class RDoc::Generator::Markdown
           .sort
           .each do |attr|
             csv << [
-              "#{display_name(klass)}.#{attr.name}",
+              "#{klass.full_name}.#{attr.name}",
               "Attribute",
               "#{output_path_for(klass)}##{attr.aref}"
             ]
@@ -258,15 +258,6 @@ class RDoc::Generator::Markdown
     return basename if dirname == "."
 
     "#{dirname}/#{basename}"
-  end
-
-  # Returns the normalized display name for a class or module.
-  #
-  # @param code_object [RDoc::Context] Class or module object.
-  #
-  # @return [String] Display name used in headings and the index.
-  def display_name(code_object)
-    code_object.full_name
   end
 
   # Returns the canonical Markdown path for a class or module.
@@ -740,17 +731,6 @@ class RDoc::Generator::Markdown
     normalized.sub(%r{\A#{Regexp.escape(root_basename)}/}, "")
   end
 
-  # Checks whether an object is more than a fabricated external namespace.
-  #
-  # @param klass [RDoc::Context] Class or module object.
-  #
-  # @return [Boolean] True when the object should have a generated page.
-  def class_renderable?(klass)
-    klass.in_files.any? ||
-      klass.any_content ||
-      klass.sections.any? { |section| section.title.to_s.match?(/\S/) || !section.to_document.empty? }
-  end
-
   # Prepares sorted objects and link lookup state for generation.
   #
   # @return [void]
@@ -760,7 +740,11 @@ class RDoc::Generator::Markdown
       raise TypeError, "RDoc markdown output directory must be a String"
     end
 
-    @classes = @store.unique_classes_and_modules.select(&:display?).select { |klass| class_renderable?(klass) }.sort
+    @classes = @store.unique_classes_and_modules.select(&:display?).select do |klass|
+      klass.in_files.any? ||
+        klass.any_content ||
+        klass.sections.any? { |section| section.title.to_s.match?(/\S/) || !section.to_document.empty? }
+    end.sort
     @class_output_paths = @classes.to_h { |klass| [klass.full_name, output_path_for(klass)] }
     @pages = @store.all_files.select(&:text?).select(&:display?).sort_by(&:base_name)
     @markdown_output_object_ids = (@classes + @pages).map(&:object_id)

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -266,7 +266,7 @@ class RDoc::Generator::Markdown
   #
   # @return [String] Display name used in headings and the index.
   def display_name(code_object)
-    class_doc_for(code_object).fetch(:display_name)
+    code_object.full_name
   end
 
   # Returns the canonical Markdown path for a class or module.
@@ -275,7 +275,7 @@ class RDoc::Generator::Markdown
   #
   # @return [String] Relative Markdown path.
   def output_path_for(code_object)
-    class_doc_for(code_object).fetch(:output_path)
+    turn_to_path(code_object.full_name)
   end
 
   # Renders a class or module reference, linking it when its documentation is emitted.
@@ -285,11 +285,11 @@ class RDoc::Generator::Markdown
   #
   # @return [String] Markdown text or link.
   def metadata_reference(target, label)
-    class_doc = @class_docs_by_name[normalized_full_name(target.full_name)] if target.respond_to?(:full_name)
+    output_path = @class_output_paths[target.full_name] if target.respond_to?(:full_name)
     cell = metadata_table_cell(label)
-    return cell unless class_doc
+    return cell unless output_path
 
-    "[#{cell}](#{class_doc.fetch(:output_path)})"
+    "[#{cell}](#{output_path})"
   end
 
   # Escapes text for a Markdown table cell.
@@ -402,7 +402,16 @@ class RDoc::Generator::Markdown
     begin
       formatter.markdown_cross_reference = RDoc::CrossReference.new(formatter.context)
       formatter.markdown_output_object_ids = @markdown_output_object_ids
-      section ? code_object.to_document.accept(formatter) : code_object.description
+      if section
+        locale = options.locale
+        documents = code_object.comments.map do |comment|
+          comment = RDoc::I18n::Text.new(comment).translate(locale) if locale
+          code_object.parse(comment)
+        end
+        RDoc::Markup::Document.new(*documents).accept(formatter)
+      else
+        code_object.description
+      end
     ensure
       formatter.markdown_cross_reference = nil
     end
@@ -731,127 +740,15 @@ class RDoc::Generator::Markdown
     normalized.sub(%r{\A#{Regexp.escape(root_basename)}/}, "")
   end
 
-  # Looks up resolved class documentation metadata.
-  #
-  # @param code_object [RDoc::Context] Class or module object.
-  #
-  # @return [Hash{Symbol => Object}] Metadata for rendering the object.
-  def class_doc_for(code_object)
-    @class_docs_by_object_id.fetch(code_object.object_id)
-  end
-
-  # Builds canonical class documentation metadata from RDoc objects.
-  #
-  # @param classes [Array<RDoc::Context>] Classes and modules to normalize.
-  #
-  # @return [Array<Hash{Symbol => Object}>] Metadata ordered by display name.
-  def build_class_docs(classes)
-    docs_by_name = {}
-
-    classes.select(&:display?).each do |klass|
-      score = class_content_score(klass)
-      next unless class_renderable?(klass, score)
-
-      display_name = normalized_full_name(klass.full_name)
-      output_path = turn_to_path(display_name)
-
-      candidate = {
-        klass: klass,
-        display_name: display_name,
-        output_path: output_path,
-        score: score
-      }
-
-      existing = docs_by_name[display_name]
-
-      if existing.nil?
-        docs_by_name[display_name] = candidate
-      elsif candidate.fetch(:score) > existing.fetch(:score)
-        docs_by_name[display_name] = candidate
-      end
-    end
-
-    docs_by_name.values
-      .sort_by { |doc| doc.fetch(:display_name) }
-  end
-
   # Checks whether an object is more than a fabricated external namespace.
   #
   # @param klass [RDoc::Context] Class or module object.
-  # @param score [Integer] Visible content score used for duplicate ranking.
   #
   # @return [Boolean] True when the object should have a generated page.
-  def class_renderable?(klass, score)
-    score.positive? ||
-      klass.sections.any? do |section|
-        section.title.to_s.match?(/\S/) || section.comments.any? { |comment| comment.text.match?(/\S/) }
-      end ||
-      (!class_has_raw_members?(klass) &&
-        !synthetic_full_name?(klass.full_name) &&
-        (klass.type == "class" || klass.in_files.any?))
-  end
-
-  # Collapses repeated namespace segments from synthetic vendored names.
-  #
-  # @param full_name [String] Full RDoc object name.
-  #
-  # @return [String] Normalized object name.
-  def normalized_full_name(full_name)
-    normalized = full_name
-
-    loop do
-      if normalized =~ /\A([^:]+)(?:::[^:]+)+::\1::(.+)\z/
-        normalized = "#{Regexp.last_match(1)}::#{Regexp.last_match(2)}"
-      end
-
-      if normalized =~ /\A(.+?)::\1\z/
-        normalized = Regexp.last_match(1)
-      end
-
-      break
-    end
-
-    normalized
-  end
-
-  # Scores how much owned content a class or module has.
-  #
-  # @param klass [RDoc::Context] Class or module object.
-  #
-  # @return [Integer] Content score used to choose duplicate docs.
-  def class_content_score(klass)
-    score = class_member_count(klass)
-    score += 1 unless klass.description.empty?
-    score
-  end
-
-  # Counts methods, constants, and attributes owned by a class or module.
-  #
-  # @param klass [RDoc::Context] Class or module object.
-  #
-  # @return [Integer] Number of owned members.
-  def class_member_count(klass)
-    klass.method_list.count(&:display?) + klass.constants.count(&:display?) + klass.attributes.count(&:display?)
-  end
-
-  # Checks whether a class or module owns any members before display filtering.
-  #
-  # @param klass [RDoc::Context] Class or module object.
-  #
-  # @return [Boolean] True when any owned member exists before display filtering.
-  def class_has_raw_members?(klass)
-    klass.method_list.any? || klass.constants.any? || klass.attributes.any?
-  end
-
-  # Checks whether a name appears to contain duplicated root namespaces.
-  #
-  # @param full_name [String] Full RDoc object name.
-  #
-  # @return [Boolean] True when the root namespace appears more than once.
-  def synthetic_full_name?(full_name)
-    parts = full_name.split("::")
-    root = parts.first
-    parts.count(root) > 1
+  def class_renderable?(klass)
+    klass.in_files.any? ||
+      klass.any_content ||
+      klass.sections.any? { |section| section.title.to_s.match?(/\S/) || !section.to_document.empty? }
   end
 
   # Prepares sorted objects and link lookup state for generation.
@@ -863,13 +760,11 @@ class RDoc::Generator::Markdown
       raise TypeError, "RDoc markdown output directory must be a String"
     end
 
-    @class_docs = build_class_docs(@store.all_classes_and_modules.sort)
-    @class_docs_by_object_id = @class_docs.to_h { |doc| [doc.fetch(:klass).object_id, doc] }
-    @class_docs_by_name = @class_docs.to_h { |doc| [doc.fetch(:display_name), doc] }
-    @classes = @class_docs.map { |doc| doc.fetch(:klass) }
+    @classes = @store.unique_classes_and_modules.select(&:display?).select { |klass| class_renderable?(klass) }.sort
+    @class_output_paths = @classes.to_h { |klass| [klass.full_name, output_path_for(klass)] }
     @pages = @store.all_files.select(&:text?).select(&:display?).sort_by(&:base_name)
     @markdown_output_object_ids = (@classes + @pages).map(&:object_id)
-    @known_output_paths = @class_docs.map { |doc| doc.fetch(:output_path) }
+    @known_output_paths = @class_output_paths.values
     @pages.each { |page| @known_output_paths << page_output_path(page) }
 
     @root_path_segment = Pathname.new(@options.root || ".").basename

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -671,6 +671,8 @@ class RDoc::Generator::Markdown
   #
   # @return [String, nil] Anchor or relative Markdown link target, or nil when the target page is omitted.
   def method_link(method, current_class:)
+    return unless method.display?
+
     target_parent = method.parent
     target_path = @class_output_paths[target_parent.full_name]
     return unless target_path

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -742,7 +742,11 @@ class RDoc::Generator::Markdown
 
     @classes = @store.unique_classes_and_modules.select(&:display?).select do |klass|
       klass.in_files.any? ||
-        klass.any_content ||
+        !klass.description.empty? ||
+        klass.includes.any? ||
+        klass.method_list.any?(&:display?) ||
+        klass.constants.any?(&:display?) ||
+        klass.attributes.any?(&:display?) ||
         klass.sections.any? { |section| section.title.to_s.match?(/\S/) || !section.to_document.empty? }
     end.sort
     @class_output_paths = @classes.to_h { |klass| [klass.full_name, output_path_for(klass)] }

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -589,7 +589,10 @@ class RDoc::Generator::Markdown
     aliased_method = method.is_alias_for
     return "Not documented." unless aliased_method
 
-    "Alias for: [`#{aliased_method.name}`](#{method_link(aliased_method, current_class: current_class)})"
+    link = method_link(aliased_method, current_class: current_class)
+    return "Alias for: `#{aliased_method.name}`" unless link
+
+    "Alias for: [`#{aliased_method.name}`](#{link})"
   end
 
   # Applies final whitespace and link normalization before writing Markdown.
@@ -666,12 +669,14 @@ class RDoc::Generator::Markdown
   # @param method [RDoc::AnyMethod] Target method.
   # @param current_class [RDoc::Context] Class or module currently being rendered.
   #
-  # @return [String] Anchor or relative Markdown link target.
+  # @return [String, nil] Anchor or relative Markdown link target, or nil when the target page is omitted.
   def method_link(method, current_class:)
     target_parent = method.parent
+    target_path = @class_output_paths[target_parent.full_name]
+    return unless target_path
     return "##{method.aref}" if target_parent == current_class
 
-    "#{output_path_for(target_parent)}##{method.aref}"
+    "#{target_path}##{method.aref}"
   end
 
   # Rewrites local Markdown links relative to the current output file.

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -396,8 +396,10 @@ class RDoc::Generator::Markdown
       if section
         locale = options.locale
         documents = code_object.comments.map do |comment|
+          next comment.parse unless locale && !comment.text.empty?
+
           comment = comment.dup
-          comment.text = RDoc::I18n::Text.new(comment).translate(locale) if locale
+          comment.text = RDoc::I18n::Text.new(comment).translate(locale)
           comment.parse
         end
         RDoc::Markup::Document.new(*documents).accept(formatter)

--- a/lib/rdoc/generator/markdown.rb
+++ b/lib/rdoc/generator/markdown.rb
@@ -775,7 +775,7 @@ class RDoc::Generator::Markdown
       .sort_by { |doc| doc.fetch(:display_name) }
   end
 
-  # Checks whether the class template has meaningful output for an object.
+  # Checks whether an object is more than a fabricated external namespace.
   #
   # @param klass [RDoc::Context] Class or module object.
   # @param score [Integer] Visible content score used for duplicate ranking.
@@ -783,10 +783,12 @@ class RDoc::Generator::Markdown
   # @return [Boolean] True when the object should have a generated page.
   def class_renderable?(klass, score)
     score.positive? ||
-      klass.sections.any? { |section| section.title.to_s.match?(/\S/) || section.comments.any? } ||
-      (!synthetic_full_name?(klass.full_name) &&
-        (klass.includes.any? ||
-          (klass.in_files.any? && !class_has_raw_members?(klass))))
+      klass.sections.any? do |section|
+        section.title.to_s.match?(/\S/) || section.comments.any? { |comment| comment.text.match?(/\S/) }
+      end ||
+      (!class_has_raw_members?(klass) &&
+        !synthetic_full_name?(klass.full_name) &&
+        (klass.type == "class" || klass.in_files.any?))
   end
 
   # Collapses repeated namespace segments from synthetic vendored names.

--- a/lib/templates/classfile.md.erb
+++ b/lib/templates/classfile.md.erb
@@ -1,4 +1,4 @@
-# <%= klass.type.capitalize %> <%= display_name(klass) %><%= anchor(klass.aref.strip) %>
+# <%= klass.type.capitalize %> <%= klass.full_name %><%= anchor(klass.aref.strip) %>
 <%- superclass = klass.superclass if klass.type == "class" -%>
 <%- includes = klass.includes -%>
 <%- source_files = klass.in_files -%>

--- a/test/data/external_namespaces.rb
+++ b/test/data/external_namespaces.rb
@@ -1,0 +1,8 @@
+class Thread::Backtrace::Location # :nodoc:
+end
+
+class URI::Generic # :nodoc:
+end
+
+class Process::Status # :nodoc:
+end

--- a/test/support/rdoc.rb
+++ b/test/support/rdoc.rb
@@ -75,6 +75,7 @@ module RDocTestHelpers
     RDoc::NormalClass.new(full_name).tap do |klass|
       klass.store = store
       klass.full_name = full_name
+      klass.record_location(location)
       klass.add_comment(RDoc::Comment.new(description), location) unless description.nil?
 
       Array.new(methods) { |index| klass.add_method(rdoc_method("method_#{index}")) }
@@ -91,6 +92,7 @@ module RDocTestHelpers
     RDoc::NormalModule.new(full_name).tap do |mod|
       mod.store = store
       mod.full_name = full_name
+      mod.record_location(location)
       mod.add_comment(RDoc::Comment.new(description), location) unless description.nil?
 
       Array.new(methods) { |index| mod.add_method(rdoc_method("method_#{index}")) }

--- a/test/support/rdoc.rb
+++ b/test/support/rdoc.rb
@@ -31,8 +31,8 @@ module RDocTestHelpers
     end
   end
 
-  def rdoc_store(classes: [], pages: nil)
-    RDoc::Store.new(RDoc::Options.new).tap do |store|
+  def rdoc_store(classes: [], pages: nil, options: RDoc::Options.new)
+    RDoc::Store.new(options).tap do |store|
       classes.each do |klass|
         klass.store = store
         (klass.module? ? store.modules_hash : store.classes_hash)[klass.full_name] = klass
@@ -43,7 +43,7 @@ module RDocTestHelpers
         store.files_hash[page.relative_name] = page
       end
 
-      store.complete(:public)
+      store.complete(options.visibility)
     end
   end
 

--- a/test/support/rdoc.rb
+++ b/test/support/rdoc.rb
@@ -35,7 +35,7 @@ module RDocTestHelpers
     RDoc::Store.new(RDoc::Options.new).tap do |store|
       classes.each do |klass|
         klass.store = store
-        store.classes_hash[klass.full_name] = klass
+        (klass.module? ? store.modules_hash : store.classes_hash)[klass.full_name] = klass
       end
 
       Array(pages).each do |page|
@@ -69,7 +69,7 @@ module RDocTestHelpers
     end
   end
 
-  def build_rdoc_class(full_name:, description: "", methods: 0, constants: 0, attributes: 0)
+  def build_rdoc_class(full_name:, description: "", methods: 0, constants: 0, attributes: 0, source_backed: false)
     store = rdoc_store
     location = RDoc::TopLevel.new("#{full_name.tr(":", "_")}.rb")
     location.store = store
@@ -77,7 +77,7 @@ module RDocTestHelpers
     RDoc::NormalClass.new(full_name).tap do |klass|
       klass.store = store
       klass.full_name = full_name
-      klass.record_location(location)
+      klass.record_location(location) if source_backed
       klass.add_comment(RDoc::Comment.new(description), location) unless description.nil?
 
       Array.new(methods) { |index| klass.add_method(rdoc_method("method_#{index}")) }
@@ -86,7 +86,7 @@ module RDocTestHelpers
     end
   end
 
-  def build_rdoc_module(full_name:, description: "", methods: 0, constants: 0, attributes: 0)
+  def build_rdoc_module(full_name:, description: "", methods: 0, constants: 0, attributes: 0, source_backed: false)
     store = rdoc_store
     location = RDoc::TopLevel.new("#{full_name.tr(":", "_")}.rb")
     location.store = store
@@ -94,7 +94,7 @@ module RDocTestHelpers
     RDoc::NormalModule.new(full_name).tap do |mod|
       mod.store = store
       mod.full_name = full_name
-      mod.record_location(location)
+      mod.record_location(location) if source_backed
       mod.add_comment(RDoc::Comment.new(description), location) unless description.nil?
 
       Array.new(methods) { |index| mod.add_method(rdoc_method("method_#{index}")) }

--- a/test/support/rdoc.rb
+++ b/test/support/rdoc.rb
@@ -42,6 +42,8 @@ module RDocTestHelpers
         page.store = store
         store.files_hash[page.relative_name] = page
       end
+
+      store.complete(:public)
     end
   end
 

--- a/test/test_class_docs.rb
+++ b/test/test_class_docs.rb
@@ -317,6 +317,15 @@ class TestClassDocs < Minitest::Test
     assert_includes index_entries(dir), ["Alpha::Another", "Class", "Alpha/Another.md"]
   end
 
+  def test_generate_skips_zero_score_classes_without_source_files
+    external = RDoc::NormalModule.new("External")
+
+    dir = generate_from_store([external])
+
+    assert_false File.exist?(File.join(dir, "External.md"))
+    assert_predicate index_entries(dir), :empty?
+  end
+
   def test_generate_keeps_empty_namespace_modules_that_contain_documented_children
     namespace = build_rdoc_module(full_name: "Jekyll")
     child = build_rdoc_class(full_name: "Jekyll::SeoTag", methods: 1)

--- a/test/test_class_docs.rb
+++ b/test/test_class_docs.rb
@@ -307,6 +307,17 @@ class TestClassDocs < Minitest::Test
     assert_predicate index_entries(dir), :empty?
   end
 
+  def test_generate_skips_hidden_only_classes_with_implicit_superclasses
+    klass = build_rdoc_class(full_name: "ImplicitSuperclass")
+    klass.superclass = "Object"
+    klass.add_method(rdoc_method("hidden_method", visible: false))
+
+    dir = generate_from_store([klass])
+
+    assert_false File.exist?(File.join(dir, "ImplicitSuperclass.md"))
+    assert_predicate index_entries(dir), :empty?
+  end
+
   def test_generate_keeps_namespace_when_hidden_descendants_are_skipped
     namespace = build_rdoc_module(full_name: "HiddenNamespace")
     hidden_child = build_rdoc_class(full_name: "HiddenNamespace::Child")
@@ -363,16 +374,13 @@ class TestClassDocs < Minitest::Test
     assert_predicate index_entries(dir), :empty?
   end
 
-  def test_generate_keeps_source_less_classes_with_template_metadata
-    inherited = RDoc::NormalClass.new("InheritedOnly", "ExternalBase")
+  def test_generate_keeps_source_less_modules_with_include_metadata
     included = RDoc::NormalModule.new("IncludedOnly")
     included.add_include(RDoc::Include.new("ExternalMixin", ""))
 
-    dir = generate_from_store([inherited, included])
+    dir = generate_from_store([included])
 
-    assert_includes File.read(File.join(dir, "InheritedOnly.md")), "| **Inherits** | ExternalBase |"
     assert_includes File.read(File.join(dir, "IncludedOnly.md")), "| **Includes** | ExternalMixin |"
-    assert_includes index_entries(dir), ["InheritedOnly", "Class", "InheritedOnly.md"]
     assert_includes index_entries(dir), ["IncludedOnly", "Module", "IncludedOnly.md"]
   end
 

--- a/test/test_class_docs.rb
+++ b/test/test_class_docs.rb
@@ -196,6 +196,20 @@ class TestClassDocs < Minitest::Test
     assert_false File.exist?(File.join(dir, "Ghost/Ghost/Thing.md"))
   end
 
+  def test_generate_ignores_unrenderable_candidate_before_resolving_duplicate_docs
+    synthetic = build_rdoc_class(full_name: "Root::Inner::Root::Thing")
+    real = build_rdoc_class(full_name: "Root::Thing")
+    real.add_section("Overview")
+
+    dir = generate_from_store([synthetic, real])
+    canonical_path = File.join(dir, "Root/Thing.md")
+
+    assert_true File.exist?(canonical_path)
+    assert_includes File.read(canonical_path), "## Overview"
+    assert_includes index_entries(dir), ["Root::Thing", "Class", "Root/Thing.md"]
+    assert_false File.exist?(File.join(dir, "Root/Inner/Root/Thing.md"))
+  end
+
   def test_generate_ignores_zero_score_later_duplicate
     real = build_rdoc_class(
       full_name: "Later::Thing",
@@ -581,12 +595,13 @@ class TestClassDocs < Minitest::Test
 
   def test_whitespace_only_description_does_not_create_positive_score
     duplicate = build_rdoc_class(full_name: "Blank::A::Blank::Winner")
+    duplicate.add_section("Synthetic")
     whitespace = build_rdoc_class(full_name: "Blank::Winner", description: " \n\t")
 
     dir = generate_from_store([duplicate, whitespace])
 
-    assert_false File.exist?(File.join(dir, "Blank/Winner.md"))
-    assert_predicate index_entries(dir), :empty?
+    assert_includes File.read(File.join(dir, "Blank/Winner.md")), "## Synthetic"
+    assert_includes index_entries(dir), ["Blank::Winner", "Class", "Blank/Winner.md"]
   end
 
   def test_generate_sorts_class_docs_by_normalized_display_name

--- a/test/test_class_docs.rb
+++ b/test/test_class_docs.rb
@@ -11,6 +11,7 @@ class TestClassDocs < Minitest::Test
   cover "RDoc::Generator::Markdown#build_class_docs"
   cover "RDoc::Generator::Markdown#class_member_count"
   cover "RDoc::Generator::Markdown#class_has_raw_members?"
+  cover "RDoc::Generator::Markdown#class_renderable?"
   cover "RDoc::Generator::Markdown#class_content_score"
   cover "RDoc::Generator::Markdown#class_doc_for"
   cover "RDoc::Generator::Markdown#display_name"
@@ -338,6 +339,19 @@ class TestClassDocs < Minitest::Test
 
     assert_false File.exist?(File.join(dir, "External.md"))
     assert_predicate index_entries(dir), :empty?
+  end
+
+  def test_generate_keeps_source_less_classes_with_template_metadata
+    inherited = RDoc::NormalClass.new("InheritedOnly", "ExternalBase")
+    included = RDoc::NormalModule.new("IncludedOnly")
+    included.add_include(RDoc::Include.new("ExternalMixin", ""))
+
+    dir = generate_from_store([inherited, included])
+
+    assert_includes File.read(File.join(dir, "InheritedOnly.md")), "| **Inherits** | ExternalBase |"
+    assert_includes File.read(File.join(dir, "IncludedOnly.md")), "| **Includes** | ExternalMixin |"
+    assert_includes index_entries(dir), ["InheritedOnly", "Class", "InheritedOnly.md"]
+    assert_includes index_entries(dir), ["IncludedOnly", "Module", "IncludedOnly.md"]
   end
 
   def test_generate_keeps_empty_namespace_modules_that_contain_documented_children

--- a/test/test_class_docs.rb
+++ b/test/test_class_docs.rb
@@ -118,13 +118,13 @@ class TestClassDocs < Minitest::Test
 
   def test_generate_does_not_add_spacing_without_metadata
     mod = RDoc::NormalModule.new("ActiveModel::API")
-    mod.add_section("Active Model API")
+    mod.add_section("Overview")
 
     dir = generate_from_store([mod])
 
     assert_eql <<~MARKDOWN, File.read(File.join(dir, "ActiveModel/API.md"))
       # Module ActiveModel::API<a id="module-activemodel-api"></a>
-      ## Active Model API
+      ## Overview
     MARKDOWN
   end
 

--- a/test/test_class_docs.rb
+++ b/test/test_class_docs.rb
@@ -129,6 +129,16 @@ class TestClassDocs < Minitest::Test
     MARKDOWN
   end
 
+  def test_generate_keeps_title_only_sections
+    mod = RDoc::NormalModule.new("TitleOnly")
+    mod.add_section("Overview")
+
+    dir = generate_from_store([mod])
+
+    assert_includes File.read(File.join(dir, "TitleOnly.md")), "## Overview"
+    assert_includes index_entries(dir), ["TitleOnly", "Module", "TitleOnly.md"]
+  end
+
   def test_generate_normalizes_synthetic_class_with_multiple_middle_segments
     synthetic = build_rdoc_class(
       full_name: "Root::One::Two::Root::Thing",
@@ -181,6 +191,18 @@ class TestClassDocs < Minitest::Test
     canonical_path = File.join(dir, "Alpha/Thing.md")
 
     assert_includes File.read(canonical_path), "Real doc"
+  end
+
+  def test_generate_ignores_section_titles_when_selecting_duplicates
+    titled = build_rdoc_class(full_name: "TitleScore::Inner::TitleScore::Thing", methods: 1)
+    titled.add_section("Synthetic category")
+    membered = build_rdoc_class(full_name: "TitleScore::Thing", methods: 2)
+
+    dir = generate_from_store([titled, membered])
+    markdown = File.read(File.join(dir, "TitleScore/Thing.md"))
+
+    assert_includes markdown, "#### `method_1()`"
+    refute_includes markdown, "## Synthetic category"
   end
 
   def test_generate_replaces_zero_score_candidate

--- a/test/test_class_docs.rb
+++ b/test/test_class_docs.rb
@@ -8,8 +8,6 @@ require "rdoc/rdoc"
 require "rdoc/markdown"
 
 class TestClassDocs < Minitest::Test
-  cover "RDoc::Generator::Markdown#class_renderable?"
-  cover "RDoc::Generator::Markdown#display_name"
   cover "RDoc::Generator::Markdown#emit_classfiles"
   cover "RDoc::Generator::Markdown#emit_csv_index"
   cover "RDoc::Generator::Markdown#generate"

--- a/test/test_class_docs.rb
+++ b/test/test_class_docs.rb
@@ -36,16 +36,8 @@ class TestClassDocs < Minitest::Test
   end
 
   def test_generate_preserves_distinct_repeated_namespaces
-    nested = build_rdoc_class(
-      full_name: "VendoredPathExpander::Minitest::VendoredPathExpander::PathExpander",
-      description: "Nested doc",
-      methods: 1
-    )
-    canonical = build_rdoc_class(
-      full_name: "VendoredPathExpander::PathExpander",
-      description: "Canonical doc",
-      methods: 2
-    )
+    nested = build_rdoc_class(full_name: "VendoredPathExpander::Minitest::VendoredPathExpander::PathExpander", description: "Nested doc")
+    canonical = build_rdoc_class(full_name: "VendoredPathExpander::PathExpander", description: "Canonical doc")
 
     dir = generate_from_store([nested, canonical])
 
@@ -68,7 +60,6 @@ class TestClassDocs < Minitest::Test
     RDoc::Generator::Markdown.new(store, options).generate
 
     assert_eql 1, index_entries(options.op_dir).count { |name, type, _path| name == "Canonical" && type == "Class" }
-    assert_false File.exist?(File.join(options.op_dir, "Alias.md"))
   end
 
   def test_generate_renders_metadata_as_table_cells
@@ -117,16 +108,6 @@ class TestClassDocs < Minitest::Test
       # Module ActiveModel::API<a id="module-activemodel-api"></a>
       ## Overview
     MARKDOWN
-  end
-
-  def test_generate_keeps_title_only_sections
-    mod = RDoc::NormalModule.new("TitleOnly")
-    mod.add_section("Overview")
-
-    dir = generate_from_store([mod])
-
-    assert_includes File.read(File.join(dir, "TitleOnly.md")), "## Overview"
-    assert_includes index_entries(dir), ["TitleOnly", "Module", "TitleOnly.md"]
   end
 
   def test_generate_keeps_source_backed_empty_classes

--- a/test/test_class_docs.rb
+++ b/test/test_class_docs.rb
@@ -165,6 +165,17 @@ class TestClassDocs < Minitest::Test
     assert_false File.exist?(File.join(dir, "ExternalBase.md"))
   end
 
+  def test_generate_formats_source_less_descriptions_once
+    mod = build_rdoc_module(
+      full_name: "Documented",
+      description: "See {Missing}[rdoc-ref:Missing]."
+    )
+
+    stdout, = capture_io { generate_from_store([mod]) }
+
+    assert_eql 1, stdout.scan("can't be resolved").length
+  end
+
   def test_generate_skips_source_less_modules_with_only_hidden_members
     mod = RDoc::NormalModule.new("HiddenOnly")
     mod.add_method(rdoc_method("hidden", visible: false))

--- a/test/test_class_docs.rb
+++ b/test/test_class_docs.rb
@@ -374,14 +374,23 @@ class TestClassDocs < Minitest::Test
     assert_predicate index_entries(dir), :empty?
   end
 
-  def test_generate_keeps_source_less_modules_with_include_metadata
-    included = RDoc::NormalModule.new("IncludedOnly")
-    included.add_include(RDoc::Include.new("ExternalMixin", ""))
+  def test_generate_keeps_source_less_classes_with_inheritance_metadata
+    inherited = RDoc::NormalClass.new("InheritedOnly", "ExternalBase")
 
-    dir = generate_from_store([included])
+    dir = generate_from_store([inherited])
 
-    assert_includes File.read(File.join(dir, "IncludedOnly.md")), "| **Includes** | ExternalMixin |"
-    assert_includes index_entries(dir), ["IncludedOnly", "Module", "IncludedOnly.md"]
+    assert_includes File.read(File.join(dir, "InheritedOnly.md")), "| **Inherits** | ExternalBase |"
+    assert_includes index_entries(dir), ["InheritedOnly", "Class", "InheritedOnly.md"]
+  end
+
+  def test_generate_skips_source_less_modules_with_whitespace_only_section_comments
+    mod = RDoc::NormalModule.new("WhitespaceOnly")
+    mod.add_section(nil, RDoc::Comment.new(" \n\t"))
+
+    dir = generate_from_store([mod])
+
+    assert_false File.exist?(File.join(dir, "WhitespaceOnly.md"))
+    assert_predicate index_entries(dir), :empty?
   end
 
   def test_generate_keeps_empty_namespace_modules_that_contain_documented_children

--- a/test/test_class_docs.rb
+++ b/test/test_class_docs.rb
@@ -30,11 +30,6 @@ class TestClassDocs < Minitest::Test
     child.parent = parent
   end
 
-  def nest_module(parent, child)
-    parent.modules_hash[child.name] = child
-    child.parent = parent
-  end
-
   def test_generate_preserves_distinct_repeated_namespaces
     nested = build_rdoc_class(full_name: "VendoredPathExpander::Minitest::VendoredPathExpander::PathExpander", description: "Nested doc")
     canonical = build_rdoc_class(full_name: "VendoredPathExpander::PathExpander", description: "Canonical doc")
@@ -111,8 +106,8 @@ class TestClassDocs < Minitest::Test
   end
 
   def test_generate_keeps_source_backed_empty_classes
-    real = build_rdoc_class(full_name: "Shell")
-    nested = build_rdoc_class(full_name: "Alpha::Another")
+    real = build_rdoc_class(full_name: "Shell", source_backed: true)
+    nested = build_rdoc_class(full_name: "Alpha::Another", source_backed: true)
 
     dir = generate_from_store([real, nested])
 
@@ -153,7 +148,7 @@ class TestClassDocs < Minitest::Test
     attributed = RDoc::NormalModule.new("AttributeOnly")
     attributed.add_attribute(rdoc_attribute("name"))
     omitted = RDoc::NormalClass.new("ExternalBase")
-    child = build_rdoc_class(full_name: "Child")
+    child = build_rdoc_class(full_name: "Child", source_backed: true)
     child.superclass = omitted
 
     dir = generate_from_store([included, described, methoded, constant, attributed, omitted, child])
@@ -192,9 +187,9 @@ class TestClassDocs < Minitest::Test
     assert_predicate index_entries(dir), :empty?
   end
 
-  def test_generate_keeps_empty_namespace_modules_that_contain_documented_children
-    namespace = build_rdoc_module(full_name: "Jekyll")
-    child = build_rdoc_class(full_name: "Jekyll::SeoTag", methods: 1)
+  def test_generate_keeps_source_backed_namespace_declarations
+    namespace = build_rdoc_module(full_name: "Jekyll", source_backed: true)
+    child = build_rdoc_class(full_name: "Jekyll::SeoTag", source_backed: true)
     nest_class(namespace, child)
 
     dir = generate_from_store([namespace, child])
@@ -205,182 +200,19 @@ class TestClassDocs < Minitest::Test
     assert_includes index_entries(dir), ["Jekyll::SeoTag", "Class", "Jekyll/SeoTag.md"]
   end
 
-  def test_generate_keeps_empty_namespace_modules_that_contain_nested_modules
+  def test_generate_skips_source_less_ancestors_of_rendered_descendants
     namespace = build_rdoc_module(full_name: "Jekyll")
-    child = build_rdoc_module(full_name: "Jekyll::SeoTag", methods: 1)
-    nest_module(namespace, child)
-
-    dir = generate_from_store([namespace, child])
-
-    assert_true File.exist?(File.join(dir, "Jekyll.md"))
-    assert_true File.exist?(File.join(dir, "Jekyll/SeoTag.md"))
-    assert_includes index_entries(dir), ["Jekyll", "Module", "Jekyll.md"]
-    assert_includes index_entries(dir), ["Jekyll::SeoTag", "Module", "Jekyll/SeoTag.md"]
-  end
-
-  def test_generate_keeps_described_namespace_without_api_descendants
-    namespace = build_rdoc_module(full_name: "Liquid", description: "Prevent bundler errors")
-    child = build_rdoc_class(full_name: "Liquid::Tag")
-    nest_class(namespace, child)
-
-    dir = generate_from_store([namespace, child])
-
-    assert_true File.exist?(File.join(dir, "Liquid.md"))
-    assert_true File.exist?(File.join(dir, "Liquid/Tag.md"))
-    assert_includes index_entries(dir), ["Liquid", "Module", "Liquid.md"]
-    assert_includes index_entries(dir), ["Liquid::Tag", "Class", "Liquid/Tag.md"]
-  end
-
-  def test_generate_keeps_empty_child_declaration_under_empty_namespace_module
-    namespace = build_rdoc_module(full_name: "Ocean")
-    child = build_rdoc_class(full_name: "Ocean::Salmon")
-    nest_class(namespace, child)
-
-    dir = generate_from_store([namespace, child])
-
-    assert_true File.exist?(File.join(dir, "Ocean.md"))
-    assert_true File.exist?(File.join(dir, "Ocean/Salmon.md"))
-    assert_includes index_entries(dir), ["Ocean", "Module", "Ocean.md"]
-    assert_includes index_entries(dir), ["Ocean::Salmon", "Class", "Ocean/Salmon.md"]
-  end
-
-  def test_generate_keeps_empty_child_declaration_under_membered_namespace
-    namespace = build_rdoc_module(full_name: "Liquid", description: "Real namespace", methods: 1)
-    child = build_rdoc_class(full_name: "Liquid::Tag")
-    nest_class(namespace, child)
-
-    dir = generate_from_store([namespace, child])
-
-    assert_true File.exist?(File.join(dir, "Liquid.md"))
-    assert_true File.exist?(File.join(dir, "Liquid/Tag.md"))
-    assert_includes index_entries(dir), ["Liquid", "Module", "Liquid.md"]
-    assert_includes index_entries(dir), ["Liquid::Tag", "Class", "Liquid/Tag.md"]
-  end
-
-  def test_generate_keeps_described_namespace_when_empty_child_has_documented_child
-    namespace = build_rdoc_module(full_name: "Liquid", description: "Real namespace")
-    child = build_rdoc_class(full_name: "Liquid::Tag")
-    grandchild = build_rdoc_class(full_name: "Liquid::Tag::Block", methods: 1)
+    child = build_rdoc_class(full_name: "Jekyll::SeoTag")
+    grandchild = build_rdoc_class(full_name: "Jekyll::SeoTag::Drop", methods: 1)
     nest_class(namespace, child)
     nest_class(child, grandchild)
 
     dir = generate_from_store([namespace, child, grandchild])
 
-    assert_true File.exist?(File.join(dir, "Liquid.md"))
-    assert_true File.exist?(File.join(dir, "Liquid/Tag.md"))
-    assert_true File.exist?(File.join(dir, "Liquid/Tag/Block.md"))
-    assert_includes index_entries(dir), ["Liquid", "Module", "Liquid.md"]
-    assert_includes index_entries(dir), ["Liquid::Tag", "Class", "Liquid/Tag.md"]
-    assert_includes index_entries(dir), ["Liquid::Tag::Block", "Class", "Liquid/Tag/Block.md"]
-  end
-
-  def test_generate_keeps_described_namespace_with_mixed_empty_and_api_children
-    namespace = build_rdoc_module(full_name: "Liquid", description: "Real namespace")
-    empty_child = build_rdoc_class(full_name: "Liquid::Tag")
-    documented_child = build_rdoc_class(full_name: "Liquid::Drop", methods: 1)
-    nest_class(namespace, empty_child)
-    nest_class(namespace, documented_child)
-
-    dir = generate_from_store([namespace, empty_child, documented_child])
-
-    assert_true File.exist?(File.join(dir, "Liquid.md"))
-    assert_true File.exist?(File.join(dir, "Liquid/Tag.md"))
-    assert_true File.exist?(File.join(dir, "Liquid/Drop.md"))
-    assert_includes index_entries(dir), ["Liquid", "Module", "Liquid.md"]
-    assert_includes index_entries(dir), ["Liquid::Tag", "Class", "Liquid/Tag.md"]
-    assert_includes index_entries(dir), ["Liquid::Drop", "Class", "Liquid/Drop.md"]
-  end
-
-  def test_generate_keeps_documented_namespace_modules_with_documented_children
-    namespace = build_rdoc_module(full_name: "Useful", description: "Useful namespace")
-    child = build_rdoc_class(full_name: "Useful::Thing", methods: 1)
-    nested = build_rdoc_module(full_name: "Useful::Nested", description: "Nested module")
-    nest_class(namespace, child)
-    nest_module(namespace, nested)
-
-    dir = generate_from_store([namespace, child, nested])
-
-    assert_true File.exist?(File.join(dir, "Useful.md"))
-    assert_true File.exist?(File.join(dir, "Useful/Thing.md"))
-    assert_true File.exist?(File.join(dir, "Useful/Nested.md"))
-    assert_includes index_entries(dir), ["Useful", "Module", "Useful.md"]
-    assert_includes index_entries(dir), ["Useful::Thing", "Class", "Useful/Thing.md"]
-    assert_includes index_entries(dir), ["Useful::Nested", "Module", "Useful/Nested.md"]
-  end
-
-  def test_generate_keeps_described_namespace_with_api_module_descendant
-    namespace = build_rdoc_module(full_name: "Useful", description: "Useful namespace")
-    nested = build_rdoc_module(full_name: "Useful::Nested", methods: 1)
-    nest_module(namespace, nested)
-
-    dir = generate_from_store([namespace, nested])
-
-    assert_true File.exist?(File.join(dir, "Useful.md"))
-    assert_true File.exist?(File.join(dir, "Useful/Nested.md"))
-    assert_includes index_entries(dir), ["Useful", "Module", "Useful.md"]
-    assert_includes index_entries(dir), ["Useful::Nested", "Module", "Useful/Nested.md"]
-  end
-
-  def test_generate_keeps_described_namespace_with_only_description_module_descendant
-    namespace = build_rdoc_module(full_name: "Useful", description: "Useful namespace")
-    nested = build_rdoc_module(full_name: "Useful::Nested", description: "Nested module")
-    nest_module(namespace, nested)
-
-    dir = generate_from_store([namespace, nested])
-
-    assert_true File.exist?(File.join(dir, "Useful.md"))
-    assert_true File.exist?(File.join(dir, "Useful/Nested.md"))
-    assert_includes index_entries(dir), ["Useful", "Module", "Useful.md"]
-    assert_includes index_entries(dir), ["Useful::Nested", "Module", "Useful/Nested.md"]
-  end
-
-  def test_generate_keeps_classes_with_members_and_nested_children
-    parent = build_rdoc_class(full_name: "Jekyll::SeoTag", methods: 1)
-    child = build_rdoc_class(full_name: "Jekyll::SeoTag::Drop", methods: 1)
-    nest_class(parent, child)
-
-    dir = generate_from_store([parent, child])
-
-    assert_true File.exist?(File.join(dir, "Jekyll/SeoTag.md"))
+    assert_false File.exist?(File.join(dir, "Jekyll.md"))
+    assert_false File.exist?(File.join(dir, "Jekyll/SeoTag.md"))
     assert_true File.exist?(File.join(dir, "Jekyll/SeoTag/Drop.md"))
-    assert_includes index_entries(dir), ["Jekyll::SeoTag", "Class", "Jekyll/SeoTag.md"]
     assert_includes index_entries(dir), ["Jekyll::SeoTag::Drop", "Class", "Jekyll/SeoTag/Drop.md"]
-  end
-
-  def test_generate_keeps_classes_with_attribute_only_content
-    attributed = build_rdoc_class(full_name: "AttributeOnly", attributes: 1)
-
-    dir = generate_from_store([attributed])
-
-    assert_true File.exist?(File.join(dir, "AttributeOnly.md"))
-    assert_includes index_entries(dir), ["AttributeOnly", "Class", "AttributeOnly.md"]
-  end
-
-  def test_generate_keeps_classes_with_constant_only_content
-    constant_only = build_rdoc_class(full_name: "ConstantOnly", constants: 1)
-
-    dir = generate_from_store([constant_only])
-
-    assert_true File.exist?(File.join(dir, "ConstantOnly.md"))
-    assert_includes index_entries(dir), ["ConstantOnly", "Class", "ConstantOnly.md"]
-  end
-
-  def test_generate_keeps_classes_with_description_only_content
-    described = build_rdoc_class(full_name: "DescriptionOnly", description: "Only docs")
-
-    dir = generate_from_store([described])
-
-    assert_true File.exist?(File.join(dir, "DescriptionOnly.md"))
-    assert_includes index_entries(dir), ["DescriptionOnly", "Class", "DescriptionOnly.md"]
-  end
-
-  def test_generate_handles_nil_descriptions_when_other_content_is_present
-    described = build_rdoc_class(full_name: "NilDescription", description: nil, methods: 1)
-
-    dir = generate_from_store([described])
-
-    assert_true File.exist?(File.join(dir, "NilDescription.md"))
-    assert_includes index_entries(dir), ["NilDescription", "Class", "NilDescription.md"]
   end
 
   def test_generate_sorts_classes_by_full_name

--- a/test/test_class_docs.rb
+++ b/test/test_class_docs.rb
@@ -17,9 +17,10 @@ class TestClassDocs < Minitest::Test
   cover "RDoc::Generator::Markdown#setup"
 
   def generate_from_store(classes, pages: nil, dir: stable_tmpdir("generate-from-store"), root: nil)
+    options = generator_options(op_dir: dir, root: root)
     generator = RDoc::Generator::Markdown.new(
-      rdoc_store(classes: classes, pages: pages),
-      generator_options(op_dir: dir, root: root)
+      rdoc_store(classes: classes, pages: pages, options: options),
+      options
     )
     generator.generate
     dir

--- a/test/test_class_docs.rb
+++ b/test/test_class_docs.rb
@@ -141,21 +141,45 @@ class TestClassDocs < Minitest::Test
     assert_predicate index_entries(dir), :empty?
   end
 
-  def test_generate_keeps_source_less_modules_with_content
+  def test_generate_keeps_source_less_modules_with_rendered_content
     included = RDoc::NormalModule.new("IncludedOnly")
     included.add_include(RDoc::Include.new("ExternalMixin", ""))
+    described = RDoc::NormalModule.new("DescribedOnly")
+    described.add_comment(RDoc::Comment.new("Only docs"), RDoc::TopLevel.new("external.rb"))
+    methoded = RDoc::NormalModule.new("MethodOnly")
+    methoded.add_method(rdoc_method("run"))
+    constant = RDoc::NormalModule.new("ConstantOnly")
+    constant.add_constant(rdoc_constant("VALUE"))
+    attributed = RDoc::NormalModule.new("AttributeOnly")
+    attributed.add_attribute(rdoc_attribute("name"))
     omitted = RDoc::NormalClass.new("ExternalBase")
     child = build_rdoc_class(full_name: "Child")
     child.superclass = omitted
 
-    dir = generate_from_store([included, omitted, child])
+    dir = generate_from_store([included, described, methoded, constant, attributed, omitted, child])
     markdown = File.read(File.join(dir, "IncludedOnly.md"))
     child_markdown = File.read(File.join(dir, "Child.md"))
 
     assert_includes markdown, "| **Includes** | ExternalMixin |"
+    assert_includes File.read(File.join(dir, "DescribedOnly.md")), "Only docs"
+    assert_includes File.read(File.join(dir, "MethodOnly.md")), "#### `run()`"
+    assert_includes File.read(File.join(dir, "ConstantOnly.md")), "#### `VALUE`"
+    assert_includes File.read(File.join(dir, "AttributeOnly.md")), "#### `name`"
     assert_includes child_markdown, "| **Inherits** | ExternalBase |"
     refute_includes child_markdown, "[ExternalBase]"
     assert_false File.exist?(File.join(dir, "ExternalBase.md"))
+  end
+
+  def test_generate_skips_source_less_modules_with_only_hidden_members
+    mod = RDoc::NormalModule.new("HiddenOnly")
+    mod.add_method(rdoc_method("hidden", visible: false))
+    mod.add_constant(rdoc_constant("HIDDEN", visible: false))
+    mod.add_attribute(rdoc_attribute("hidden", visible: false))
+
+    dir = generate_from_store([mod])
+
+    assert_false File.exist?(File.join(dir, "HiddenOnly.md"))
+    assert_predicate index_entries(dir), :empty?
   end
 
   def test_generate_skips_source_less_modules_with_whitespace_only_section_comments

--- a/test/test_class_docs.rb
+++ b/test/test_class_docs.rb
@@ -8,22 +8,15 @@ require "rdoc/rdoc"
 require "rdoc/markdown"
 
 class TestClassDocs < Minitest::Test
-  cover "RDoc::Generator::Markdown#build_class_docs"
-  cover "RDoc::Generator::Markdown#class_member_count"
-  cover "RDoc::Generator::Markdown#class_has_raw_members?"
   cover "RDoc::Generator::Markdown#class_renderable?"
-  cover "RDoc::Generator::Markdown#class_content_score"
-  cover "RDoc::Generator::Markdown#class_doc_for"
   cover "RDoc::Generator::Markdown#display_name"
   cover "RDoc::Generator::Markdown#emit_classfiles"
   cover "RDoc::Generator::Markdown#emit_csv_index"
   cover "RDoc::Generator::Markdown#generate"
   cover "RDoc::Generator::Markdown#metadata_reference"
   cover "RDoc::Generator::Markdown#metadata_table_cell"
-  cover "RDoc::Generator::Markdown#normalized_full_name"
   cover "RDoc::Generator::Markdown#output_path_for"
   cover "RDoc::Generator::Markdown#setup"
-  cover "RDoc::Generator::Markdown#synthetic_full_name?"
 
   def generate_from_store(classes, pages: nil, dir: stable_tmpdir("generate-from-store"), root: nil)
     generator = RDoc::Generator::Markdown.new(
@@ -32,16 +25,6 @@ class TestClassDocs < Minitest::Test
     )
     generator.generate
     dir
-  end
-
-  def assert_positive_score_beats_zero_score_duplicate(primary)
-    duplicate = build_rdoc_class(full_name: "#{primary.full_name}::#{primary.full_name}")
-
-    dir = generate_from_store([primary, duplicate])
-    canonical_path = File.join(dir, "#{primary.full_name.tr(":", "/").gsub("//", "/")}.md")
-
-    assert_true File.exist?(canonical_path)
-    assert_eql 1, index_entries(dir).count { |entry| entry == [primary.full_name, "Class", "#{primary.full_name.tr(":", "/")}.md"] }
   end
 
   def nest_class(parent, child)
@@ -54,31 +37,40 @@ class TestClassDocs < Minitest::Test
     child.parent = parent
   end
 
-  def test_generate_prefers_best_normalized_class_doc
-    synthetic = build_rdoc_class(
+  def test_generate_preserves_distinct_repeated_namespaces
+    nested = build_rdoc_class(
       full_name: "VendoredPathExpander::Minitest::VendoredPathExpander::PathExpander",
-      description: "Synthetic doc",
+      description: "Nested doc",
       methods: 1
     )
-    real = build_rdoc_class(
+    canonical = build_rdoc_class(
       full_name: "VendoredPathExpander::PathExpander",
-      description: "Real doc",
+      description: "Canonical doc",
       methods: 2
     )
 
-    dir = generate_from_store([synthetic, real])
+    dir = generate_from_store([nested, canonical])
 
-    canonical_path = File.join(dir, "VendoredPathExpander/PathExpander.md")
+    assert_includes File.read(File.join(dir, "VendoredPathExpander/PathExpander.md")), "Canonical doc"
+    assert_includes File.read(File.join(dir, "VendoredPathExpander/Minitest/VendoredPathExpander/PathExpander.md")), "Nested doc"
+    assert_includes index_entries(dir),
+      ["VendoredPathExpander::Minitest::VendoredPathExpander::PathExpander", "Class",
+        "VendoredPathExpander/Minitest/VendoredPathExpander/PathExpander.md"]
+  end
 
-    assert_includes File.read(canonical_path), "# Class VendoredPathExpander::PathExpander"
-    assert_includes File.read(canonical_path), "Real doc"
-    assert_false File.exist?(File.join(dir, "VendoredPathExpander/Minitest/VendoredPathExpander/PathExpander.md"))
+  def test_generate_uses_unique_store_objects
+    klass = build_rdoc_class(full_name: "Canonical", description: "Canonical doc")
+    options = generator_options(op_dir: stable_tmpdir("unique-store-objects"))
+    store = RDoc::Store.new(options)
+    klass.store = store
+    store.classes_hash[klass.full_name] = klass
+    store.classes_hash["Alias"] = klass
+    store.complete(:public)
 
-    entries = index_entries(dir)
+    RDoc::Generator::Markdown.new(store, options).generate
 
-    assert_includes entries, ["VendoredPathExpander::PathExpander", "Class", "VendoredPathExpander/PathExpander.md"]
-    assert_eql 1, entries.count { |entry| entry == ["VendoredPathExpander::PathExpander", "Class", "VendoredPathExpander/PathExpander.md"] }
-    refute(entries.any? { |name, _type, _path| name.include?("VendoredPathExpander::Minitest::VendoredPathExpander") })
+    assert_eql 1, index_entries(options.op_dir).count { |name, type, _path| name == "Canonical" && type == "Class" }
+    assert_false File.exist?(File.join(options.op_dir, "Alias.md"))
   end
 
   def test_generate_renders_metadata_as_table_cells
@@ -139,221 +131,7 @@ class TestClassDocs < Minitest::Test
     assert_includes index_entries(dir), ["TitleOnly", "Module", "TitleOnly.md"]
   end
 
-  def test_generate_normalizes_synthetic_class_with_multiple_middle_segments
-    synthetic = build_rdoc_class(
-      full_name: "Root::One::Two::Root::Thing",
-      description: "Synthetic doc",
-      methods: 1
-    )
-    real = build_rdoc_class(
-      full_name: "Root::Thing",
-      description: "Real doc",
-      methods: 2
-    )
-
-    dir = generate_from_store([synthetic, real])
-
-    canonical_path = File.join(dir, "Root/Thing.md")
-
-    assert_includes File.read(canonical_path), "Real doc"
-
-    entries = index_entries(dir)
-    assert_includes entries, ["Root::Thing", "Class", "Root/Thing.md"]
-    refute(entries.any? { |name, _type, _path| name.include?("Root::One::Two::Root") })
-  end
-
-  def test_generate_normalizes_repeated_two_part_class_with_content
-    collapsed = build_rdoc_class(full_name: "Pair::Pair", description: "Collapsed pair")
-
-    dir = generate_from_store([collapsed])
-
-    canonical_path = File.join(dir, "Pair.md")
-
-    assert_includes File.read(canonical_path), "# Class Pair"
-    assert_includes File.read(canonical_path), "Collapsed pair"
-    assert_includes index_entries(dir), ["Pair", "Class", "Pair.md"]
-  end
-
-  def test_generate_keeps_higher_score_when_lower_score_duplicate_arrives_later
-    real = build_rdoc_class(
-      full_name: "Alpha::Thing",
-      description: "Real doc",
-      methods: 2
-    )
-    synthetic = build_rdoc_class(
-      full_name: "Alpha::Z::Alpha::Thing",
-      description: "Synthetic doc",
-      methods: 1
-    )
-
-    dir = generate_from_store([real, synthetic])
-
-    canonical_path = File.join(dir, "Alpha/Thing.md")
-
-    assert_includes File.read(canonical_path), "Real doc"
-  end
-
-  def test_generate_ignores_section_titles_when_selecting_duplicates
-    titled = build_rdoc_class(full_name: "TitleScore::Inner::TitleScore::Thing", methods: 1)
-    titled.add_section("Synthetic category")
-    membered = build_rdoc_class(full_name: "TitleScore::Thing", methods: 2)
-
-    dir = generate_from_store([titled, membered])
-    markdown = File.read(File.join(dir, "TitleScore/Thing.md"))
-
-    assert_includes markdown, "#### `method_1()`"
-    refute_includes markdown, "## Synthetic category"
-  end
-
-  def test_generate_replaces_zero_score_candidate
-    empty = build_rdoc_class(full_name: "Ghost::Ghost::Thing")
-    real = build_rdoc_class(
-      full_name: "Ghost::Thing",
-      description: "Real doc",
-      methods: 1
-    )
-
-    dir = generate_from_store([empty, real])
-
-    assert_true File.exist?(File.join(dir, "Ghost/Thing.md"))
-    assert_false File.exist?(File.join(dir, "Ghost/Ghost/Thing.md"))
-  end
-
-  def test_generate_ignores_unrenderable_candidate_before_resolving_duplicate_docs
-    synthetic = build_rdoc_class(full_name: "Root::Inner::Root::Thing")
-    real = build_rdoc_class(full_name: "Root::Thing")
-    real.add_section("Overview")
-
-    dir = generate_from_store([synthetic, real])
-    canonical_path = File.join(dir, "Root/Thing.md")
-
-    assert_true File.exist?(canonical_path)
-    assert_includes File.read(canonical_path), "## Overview"
-    assert_includes index_entries(dir), ["Root::Thing", "Class", "Root/Thing.md"]
-    assert_false File.exist?(File.join(dir, "Root/Inner/Root/Thing.md"))
-  end
-
-  def test_generate_ignores_zero_score_later_duplicate
-    real = build_rdoc_class(
-      full_name: "Later::Thing",
-      description: "Real doc",
-      methods: 1
-    )
-    empty = build_rdoc_class(full_name: "Later::Z::Later::Thing")
-
-    dir = generate_from_store([real, empty])
-
-    assert_true File.exist?(File.join(dir, "Later/Thing.md"))
-    assert_false File.exist?(File.join(dir, "Later/Z/Later/Thing.md"))
-    assert_eql 1, index_entries(dir).count { |entry| entry == ["Later::Thing", "Class", "Later/Thing.md"] }
-  end
-
-  def test_generate_writes_only_canonical_path_for_positive_score_synthetic_class
-    synthetic = build_rdoc_class(
-      full_name: "Solo::Inner::Solo::Thing",
-      description: "Synthetic doc",
-      methods: 1
-    )
-
-    dir = generate_from_store([synthetic])
-
-    canonical_path = File.join(dir, "Solo/Thing.md")
-
-    assert_true File.exist?(canonical_path)
-    assert_false File.exist?(File.join(dir, "Solo/Inner/Solo/Thing.md"))
-    assert_includes index_entries(dir), ["Solo::Thing", "Class", "Solo/Thing.md"]
-  end
-
-  def test_generate_skips_zero_score_synthetic_classes
-    synthetic = build_rdoc_class(full_name: "Root::Inner::Root::Thing")
-
-    dir = generate_from_store([synthetic])
-
-    refute File.exist?(File.join(dir, "Root/Thing.md"))
-    assert_predicate index_entries(dir), :empty?
-  end
-
-  def test_generate_skips_zero_score_classes_that_only_collapse_by_normalization
-    collapsed = build_rdoc_class(full_name: "Alpha::Alpha")
-
-    dir = generate_from_store([collapsed])
-
-    assert_false File.exist?(File.join(dir, "Alpha.md"))
-    assert_predicate index_entries(dir), :empty?
-  end
-
-  def test_generate_skips_zero_score_classes_with_synthetic_full_names
-    synthetic = build_rdoc_class(full_name: "Root::Thing::Root")
-
-    dir = generate_from_store([synthetic])
-
-    assert_false File.exist?(File.join(dir, "Root/Thing/Root.md"))
-    assert_predicate index_entries(dir), :empty?
-  end
-
-  def test_generate_skips_hidden_only_member_declarations
-    hidden_method = build_rdoc_class(full_name: "HiddenMethodOnly")
-    hidden_method.add_method(rdoc_method("hidden_method", visible: false))
-    hidden_constant = build_rdoc_class(full_name: "HiddenConstantOnly")
-    hidden_constant.add_constant(rdoc_constant("HIDDEN", visible: false))
-    hidden_attribute = build_rdoc_class(full_name: "HiddenAttributeOnly")
-    hidden_attribute.add_attribute(rdoc_attribute("hidden_attribute", visible: false))
-
-    dir = generate_from_store([hidden_method, hidden_constant, hidden_attribute])
-
-    assert_false File.exist?(File.join(dir, "HiddenMethodOnly.md"))
-    assert_false File.exist?(File.join(dir, "HiddenConstantOnly.md"))
-    assert_false File.exist?(File.join(dir, "HiddenAttributeOnly.md"))
-    assert_predicate index_entries(dir), :empty?
-  end
-
-  def test_generate_skips_hidden_only_classes_with_implicit_superclasses
-    klass = build_rdoc_class(full_name: "ImplicitSuperclass")
-    klass.superclass = "Object"
-    klass.add_method(rdoc_method("hidden_method", visible: false))
-
-    dir = generate_from_store([klass])
-
-    assert_false File.exist?(File.join(dir, "ImplicitSuperclass.md"))
-    assert_predicate index_entries(dir), :empty?
-  end
-
-  def test_generate_keeps_namespace_when_hidden_descendants_are_skipped
-    namespace = build_rdoc_module(full_name: "HiddenNamespace")
-    hidden_child = build_rdoc_class(full_name: "HiddenNamespace::Child")
-    hidden_child.add_method(rdoc_method("hidden_method", visible: false))
-    nest_class(namespace, hidden_child)
-
-    dir = generate_from_store([namespace, hidden_child])
-
-    assert_true File.exist?(File.join(dir, "HiddenNamespace.md"))
-    assert_false File.exist?(File.join(dir, "HiddenNamespace/Child.md"))
-    assert_includes index_entries(dir), ["HiddenNamespace", "Module", "HiddenNamespace.md"]
-  end
-
-  def test_generate_skips_hidden_class_before_resolving_duplicate_docs
-    hidden = build_rdoc_class(
-      full_name: "VisibleDupe::Hidden::VisibleDupe::Thing",
-      description: "Hidden duplicate",
-      methods: 2
-    )
-    hidden.done_documenting = true
-    visible = build_rdoc_class(
-      full_name: "VisibleDupe::Thing",
-      description: "Visible duplicate",
-      methods: 1
-    )
-
-    dir = generate_from_store([hidden, visible])
-
-    markdown = File.read(File.join(dir, "VisibleDupe/Thing.md"))
-    assert_includes markdown, "Visible duplicate"
-    refute_includes markdown, "Hidden duplicate"
-    assert_false File.exist?(File.join(dir, "VisibleDupe/Hidden/VisibleDupe/Thing.md"))
-    assert_includes index_entries(dir), ["VisibleDupe::Thing", "Class", "VisibleDupe/Thing.md"]
-  end
-
-  def test_generate_keeps_zero_score_real_classes
+  def test_generate_keeps_source_backed_empty_classes
     real = build_rdoc_class(full_name: "Shell")
     nested = build_rdoc_class(full_name: "Alpha::Another")
 
@@ -365,7 +143,17 @@ class TestClassDocs < Minitest::Test
     assert_includes index_entries(dir), ["Alpha::Another", "Class", "Alpha/Another.md"]
   end
 
-  def test_generate_skips_zero_score_classes_without_source_files
+  def test_generate_skips_non_displayed_classes
+    hidden = build_rdoc_class(full_name: "Hidden", description: "Hidden docs")
+    hidden.done_documenting = true
+
+    dir = generate_from_store([hidden])
+
+    assert_false File.exist?(File.join(dir, "Hidden.md"))
+    assert_predicate index_entries(dir), :empty?
+  end
+
+  def test_generate_skips_empty_classes_without_source_files
     external = RDoc::NormalModule.new("External")
 
     dir = generate_from_store([external])
@@ -374,13 +162,21 @@ class TestClassDocs < Minitest::Test
     assert_predicate index_entries(dir), :empty?
   end
 
-  def test_generate_keeps_source_less_classes_with_inheritance_metadata
-    inherited = RDoc::NormalClass.new("InheritedOnly", "ExternalBase")
+  def test_generate_keeps_source_less_modules_with_content
+    included = RDoc::NormalModule.new("IncludedOnly")
+    included.add_include(RDoc::Include.new("ExternalMixin", ""))
+    omitted = RDoc::NormalClass.new("ExternalBase")
+    child = build_rdoc_class(full_name: "Child")
+    child.superclass = omitted
 
-    dir = generate_from_store([inherited])
+    dir = generate_from_store([included, omitted, child])
+    markdown = File.read(File.join(dir, "IncludedOnly.md"))
+    child_markdown = File.read(File.join(dir, "Child.md"))
 
-    assert_includes File.read(File.join(dir, "InheritedOnly.md")), "| **Inherits** | ExternalBase |"
-    assert_includes index_entries(dir), ["InheritedOnly", "Class", "InheritedOnly.md"]
+    assert_includes markdown, "| **Includes** | ExternalMixin |"
+    assert_includes child_markdown, "| **Inherits** | ExternalBase |"
+    refute_includes child_markdown, "[ExternalBase]"
+    assert_false File.exist?(File.join(dir, "ExternalBase.md"))
   end
 
   def test_generate_skips_source_less_modules_with_whitespace_only_section_comments
@@ -557,20 +353,6 @@ class TestClassDocs < Minitest::Test
     assert_includes index_entries(dir), ["AttributeOnly", "Class", "AttributeOnly.md"]
   end
 
-  def test_attribute_only_score_beats_zero_score_duplicate
-    assert_positive_score_beats_zero_score_duplicate(build_rdoc_class(full_name: "AttributeWinner", attributes: 1))
-  end
-
-  def test_attribute_only_score_replaces_earlier_zero_score_duplicate
-    duplicate = build_rdoc_class(full_name: "Attr::A::Attr::Winner")
-    primary = build_rdoc_class(full_name: "Attr::Winner", attributes: 1)
-
-    dir = generate_from_store([duplicate, primary])
-
-    assert_false File.exist?(File.join(dir, "Attr/A/Attr/Winner.md"))
-    assert_includes File.read(File.join(dir, "Attr/Winner.md")), "# Class Attr::Winner"
-  end
-
   def test_generate_keeps_classes_with_constant_only_content
     constant_only = build_rdoc_class(full_name: "ConstantOnly", constants: 1)
 
@@ -578,20 +360,6 @@ class TestClassDocs < Minitest::Test
 
     assert_true File.exist?(File.join(dir, "ConstantOnly.md"))
     assert_includes index_entries(dir), ["ConstantOnly", "Class", "ConstantOnly.md"]
-  end
-
-  def test_constant_only_score_beats_zero_score_duplicate
-    assert_positive_score_beats_zero_score_duplicate(build_rdoc_class(full_name: "ConstantWinner", constants: 1))
-  end
-
-  def test_constant_only_score_replaces_earlier_zero_score_duplicate
-    duplicate = build_rdoc_class(full_name: "Const::A::Const::Winner")
-    primary = build_rdoc_class(full_name: "Const::Winner", constants: 1)
-
-    dir = generate_from_store([duplicate, primary])
-
-    assert_false File.exist?(File.join(dir, "Const/A/Const/Winner.md"))
-    assert_includes File.read(File.join(dir, "Const/Winner.md")), "# Class Const::Winner"
   end
 
   def test_generate_keeps_classes_with_description_only_content
@@ -612,87 +380,16 @@ class TestClassDocs < Minitest::Test
     assert_includes index_entries(dir), ["NilDescription", "Class", "NilDescription.md"]
   end
 
-  def test_description_only_score_beats_zero_score_duplicate
-    assert_positive_score_beats_zero_score_duplicate(build_rdoc_class(full_name: "DescriptionWinner", description: "Only docs"))
-  end
+  def test_generate_sorts_classes_by_full_name
+    later = build_rdoc_class(full_name: "Zoo::Bee", description: "Bee doc")
+    earlier = build_rdoc_class(full_name: "Zoo::Ant", description: "Ant doc")
 
-  def test_description_only_score_replaces_earlier_zero_score_duplicate
-    duplicate = build_rdoc_class(full_name: "Desc::A::Desc::Winner")
-    primary = build_rdoc_class(full_name: "Desc::Winner", description: "Only docs")
-
-    dir = generate_from_store([duplicate, primary])
-
-    assert_false File.exist?(File.join(dir, "Desc/A/Desc/Winner.md"))
-    assert_includes File.read(File.join(dir, "Desc/Winner.md")), "Only docs"
-  end
-
-  def test_description_only_score_ties_other_single_signal_scores
-    winner = build_rdoc_class(full_name: "DescTie::Winner", description: "Method winner", methods: 1)
-    challenger = build_rdoc_class(full_name: "DescTie::Winner::DescTie::Winner", description: "Description challenger")
-
-    dir = generate_from_store([winner, challenger])
-
-    assert_includes File.read(File.join(dir, "DescTie/Winner.md")), "Method winner"
-    refute_includes File.read(File.join(dir, "DescTie/Winner.md")), "Description challenger"
-  end
-
-  def test_description_only_score_ties_method_only_score
-    winner = build_rdoc_class(full_name: "MethodTie::Winner", description: nil, methods: 1)
-    challenger = build_rdoc_class(full_name: "MethodTie::Winner::MethodTie::Winner", description: "Description challenger")
-
-    dir = generate_from_store([winner, challenger])
-
-    assert_includes index_entries(dir), ["MethodTie::Winner", "Class", "MethodTie/Winner.md"]
-    refute_includes File.read(File.join(dir, "MethodTie/Winner.md")), "Description challenger"
-  end
-
-  def test_whitespace_only_description_does_not_create_positive_score
-    duplicate = build_rdoc_class(full_name: "Blank::A::Blank::Winner")
-    duplicate.add_section("Synthetic")
-    whitespace = build_rdoc_class(full_name: "Blank::Winner", description: " \n\t")
-
-    dir = generate_from_store([duplicate, whitespace])
-
-    assert_includes File.read(File.join(dir, "Blank/Winner.md")), "## Synthetic"
-    assert_includes index_entries(dir), ["Blank::Winner", "Class", "Blank/Winner.md"]
-  end
-
-  def test_generate_sorts_class_docs_by_normalized_display_name
-    later_full_name = build_rdoc_class(
-      full_name: "Zoo::M::Zoo::Ant",
-      description: "Ant doc",
-      methods: 1
-    )
-    earlier_full_name = build_rdoc_class(
-      full_name: "Zoo::Bee",
-      description: "Bee doc",
-      methods: 1
-    )
-
-    dir = generate_from_store([later_full_name, earlier_full_name])
+    dir = generate_from_store([later, earlier])
 
     class_entries = index_entries(dir).select { |name, type, _path| type == "Class" }
 
     assert_eql ["Zoo::Ant", "Class", "Zoo/Ant.md"], class_entries.fetch(0)
     assert_eql ["Zoo::Bee", "Class", "Zoo/Bee.md"], class_entries.fetch(1)
-  end
-
-  def test_setup_sorts_store_classes_before_resolving_equal_score_duplicates
-    sorted_winner = build_rdoc_class(
-      full_name: "Order::A::Order::Thing",
-      description: "Sorted winner",
-      methods: 1
-    )
-    unsorted_first = build_rdoc_class(
-      full_name: "Order::Thing",
-      description: "Unsorted loser",
-      methods: 1
-    )
-
-    dir = generate_from_store([unsorted_first, sorted_winner])
-
-    assert_includes File.read(File.join(dir, "Order/Thing.md")), "Sorted winner"
-    refute_includes File.read(File.join(dir, "Order/Thing.md")), "Unsorted loser"
   end
 
   def test_setup_keeps_only_displayed_pages_and_sorts_them_by_base_name
@@ -718,7 +415,7 @@ class TestClassDocs < Minitest::Test
 
   def test_generate_populates_known_output_paths_for_link_normalization
     klass = build_rdoc_class(
-      full_name: "Solo::Inner::Solo::Thing",
+      full_name: "Solo::Thing",
       description: "See {alpha}[alpha_rdoc.html], {canonical}[Solo/Thing.html], and {sibling}[Sibling.html].",
       methods: 1
     )

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -398,6 +398,9 @@ class TestGenerator < Minitest::Test
 
       module HiddenModule # :nodoc:
       end
+
+      class ExternalNamespace::HiddenClass # :nodoc:
+      end
     RUBY
 
     dir = run_generator(source, "visibility test title")
@@ -408,6 +411,7 @@ class TestGenerator < Minitest::Test
     assert_true File.exist?(File.join(dir, "Visible.md"))
     assert_false File.exist?(File.join(dir, "HiddenClass.md"))
     assert_false File.exist?(File.join(dir, "HiddenModule.md"))
+    assert_false File.exist?(File.join(dir, "ExternalNamespace.md"))
     assert_includes visible_doc, "#### `public_method()`"
     refute_includes visible_doc, "hidden_method"
     refute_includes visible_doc, "private_method"

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -176,7 +176,6 @@ class TestGenerator < Minitest::Test
           module Inner
             module Root
               class Thing
-                # :category: Synthetic category
                 def synthetic; end
               end
 
@@ -194,15 +193,6 @@ class TestGenerator < Minitest::Test
 
     assert_path_exists File.join(dir, "Root/Thing.md")
     refute_path_exists File.join(dir, "Root/Inner/Root/Thing.md")
-    thing_doc = File.read(File.join(dir, "Root/Thing.md"))
-    entries = index_entries(dir)
-
-    %w[real_one real_two].each do |method|
-      assert_includes thing_doc, "#### `#{method}()`"
-      assert_includes entries, ["Root::Thing.#{method}", "Method", "Root/Thing.md#method-i-#{method}"]
-    end
-
-    refute_includes thing_doc, "#### `synthetic()`"
     child_table = Nokogiri::HTML.fragment(Commonmarker.to_html(File.read(File.join(dir, "Child.md")))).at_css("table")
     child_inheritance = child_table.at_css("tbody tr")
 

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -176,6 +176,7 @@ class TestGenerator < Minitest::Test
           module Inner
             module Root
               class Thing
+                # :category: Synthetic category
                 def synthetic; end
               end
 
@@ -193,6 +194,15 @@ class TestGenerator < Minitest::Test
 
     assert_path_exists File.join(dir, "Root/Thing.md")
     refute_path_exists File.join(dir, "Root/Inner/Root/Thing.md")
+    thing_doc = File.read(File.join(dir, "Root/Thing.md"))
+    entries = index_entries(dir)
+
+    %w[real_one real_two].each do |method|
+      assert_includes thing_doc, "#### `#{method}()`"
+      assert_includes entries, ["Root::Thing.#{method}", "Method", "Root/Thing.md#method-i-#{method}"]
+    end
+
+    refute_includes thing_doc, "#### `synthetic()`"
     child_table = Nokogiri::HTML.fragment(Commonmarker.to_html(File.read(File.join(dir, "Child.md")))).at_css("table")
     child_inheritance = child_table.at_css("tbody tr")
 
@@ -225,6 +235,7 @@ class TestGenerator < Minitest::Test
     markdown = File.read(File.join(dir, "External/Namespace.md"))
     assert_includes markdown, "Untitled section body."
     assert_includes index_entries(dir), ["External::Namespace", "Module", "External/Namespace.md"]
+    refute_path_exists File.join(dir, "External.md")
   end
 
   def test_generator_with_private_visibility

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -9,8 +9,10 @@ require "rdoc/markdown"
 require "rdiscount"
 
 class TestGenerator < Minitest::Test
+  cover "RDoc::Generator::Markdown#class_renderable?"
   cover "RDoc::Generator::Markdown#metadata_reference"
   cover "RDoc::Generator::Markdown#method_signature"
+  cover "RDoc::Generator::Markdown#render_description"
   cover "RDoc::Generator::Markdown#setup"
 
   def source_file
@@ -215,6 +217,24 @@ class TestGenerator < Minitest::Test
 
     assert_eql ["Inherits", "Root::Inner::Root::Undocumented"], unlinked_child_inheritance.css("td").map(&:text)
     assert_empty unlinked_child_inheritance.css("a")
+  end
+
+  def test_generator_renders_untitled_sections_for_external_namespaces
+    _workspace, root = project_fixture(
+      "external-namespace-section",
+      "lib/external.rb" => <<~RUBY
+        class << External::Namespace
+          # :section:
+          # Untitled section body.
+        end
+      RUBY
+    )
+
+    dir = run_generator(File.join(root, "lib/external.rb"), "external namespace") { |options| options.root = root }
+
+    markdown = File.read(File.join(dir, "External/Namespace.md"))
+    assert_includes markdown, "Untitled section body."
+    assert_includes index_entries(dir), ["External::Namespace", "Module", "External/Namespace.md"]
   end
 
   def test_generator_with_private_visibility

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -174,6 +174,7 @@ class TestGenerator < Minitest::Test
           module Inner
             module Root
               class Thing
+                # :category: Synthetic category
                 def synthetic; end
               end
 
@@ -191,6 +192,15 @@ class TestGenerator < Minitest::Test
 
     assert_path_exists File.join(dir, "Root/Thing.md")
     refute_path_exists File.join(dir, "Root/Inner/Root/Thing.md")
+    thing_doc = File.read(File.join(dir, "Root/Thing.md"))
+    entries = index_entries(dir)
+
+    %w[real_one real_two].each do |method|
+      assert_includes thing_doc, "#### `#{method}()`"
+      assert_includes entries, ["Root::Thing.#{method}", "Method", "Root/Thing.md#method-i-#{method}"]
+    end
+
+    refute_includes thing_doc, "#### `synthetic()`"
     child_table = Nokogiri::HTML.fragment(Commonmarker.to_html(File.read(File.join(dir, "Child.md")))).at_css("table")
     child_inheritance = child_table.at_css("tbody tr")
 

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -441,6 +441,22 @@ class TestGenerator < Minitest::Test
     refute(entries.any? { |name, _type, _path| name.include?("private_method") })
   end
 
+  def test_generator_omits_external_namespaces_created_for_nodoc_classes
+    source = File.join(__dir__, "data/external_namespaces.rb")
+    dir = run_generator(source, "external namespaces")
+    entries = index_entries(dir)
+
+    [
+      ["Process", "Module", "Process.md"],
+      ["Thread", "Module", "Thread.md"],
+      ["Thread::Backtrace", "Module", "Thread/Backtrace.md"],
+      ["URI", "Module", "URI.md"]
+    ].each do |entry|
+      refute_path_exists File.join(dir, entry.last)
+      refute_includes entries, entry
+    end
+  end
+
   def test_generator_writes_nested_namespaces_to_nested_paths
     dir = run_generator(File.join(__dir__, "data/namespaced_example.rb"), "namespaced test title")
 

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -169,7 +169,6 @@ class TestGenerator < Minitest::Test
         module Root
           class Thing
             def real_one; end
-            def real_two; end
           end
 
           module Inner
@@ -191,35 +190,21 @@ class TestGenerator < Minitest::Test
 
     dir = run_generator(File.join(root, "lib/duplicates.rb"), "distinct namespaces") { |options| options.root = root }
 
-    assert_path_exists File.join(dir, "Root/Thing.md")
-    assert_path_exists File.join(dir, "Root/Inner/Root/Thing.md")
-    assert_path_exists File.join(dir, "Root/Inner/Root/Undocumented.md")
     thing_doc = File.read(File.join(dir, "Root/Thing.md"))
     nested_thing_doc = File.read(File.join(dir, "Root/Inner/Root/Thing.md"))
     entries = index_entries(dir)
 
-    %w[real_one real_two].each do |method|
-      assert_includes thing_doc, "#### `#{method}()`"
-      assert_includes entries, ["Root::Thing.#{method}", "Method", "Root/Thing.md#method-i-#{method}"]
-    end
+    assert_includes thing_doc, "#### `real_one()`"
+    assert_includes entries, ["Root::Thing.real_one", "Method", "Root/Thing.md#method-i-real_one"]
 
     assert_includes nested_thing_doc, "#### `synthetic()`"
     assert_includes nested_thing_doc, "## Synthetic category"
     assert_includes entries,
       ["Root::Inner::Root::Thing.synthetic", "Method", "Root/Inner/Root/Thing.md#method-i-synthetic"]
-    child_table = Nokogiri::HTML.fragment(Commonmarker.to_html(File.read(File.join(dir, "Child.md")))).at_css("table")
-    child_inheritance = child_table.at_css("tbody tr")
-
-    assert_eql ["Inherits", "Root::Inner::Root::Thing"], child_inheritance.css("td").map(&:text)
-    assert_eql ["Root/Inner/Root/Thing.md"], child_inheritance.css("a").map { |link| link["href"] }
-
-    unlinked_child_table = Nokogiri::HTML.fragment(
-      Commonmarker.to_html(File.read(File.join(dir, "UnlinkedChild.md")))
-    ).at_css("table")
-    unlinked_child_inheritance = unlinked_child_table.at_css("tbody tr")
-
-    assert_eql ["Inherits", "Root::Inner::Root::Undocumented"], unlinked_child_inheritance.css("td").map(&:text)
-    assert_eql ["Root/Inner/Root/Undocumented.md"], unlinked_child_inheritance.css("a").map { |link| link["href"] }
+    assert_includes File.read(File.join(dir, "Child.md")),
+      "| **Inherits** | [Root::Inner::Root::Thing](Root/Inner/Root/Thing.md) |"
+    assert_includes File.read(File.join(dir, "UnlinkedChild.md")),
+      "| **Inherits** | [Root::Inner::Root::Undocumented](Root/Inner/Root/Undocumented.md) |"
   end
 
   def test_generator_renders_untitled_sections_for_external_namespaces

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -163,7 +163,7 @@ class TestGenerator < Minitest::Test
       first_mixin_table.css("tbody tr").map { |row| row.css("td").map(&:text) }
   end
 
-  def test_generator_links_normalized_duplicate_superclass
+  def test_generator_preserves_distinct_repeated_namespaces
     _workspace, root = project_fixture(
       "normalized-superclass",
       "lib/duplicates.rb" => <<~RUBY
@@ -190,11 +190,13 @@ class TestGenerator < Minitest::Test
       RUBY
     )
 
-    dir = run_generator(File.join(root, "lib/duplicates.rb"), "normalized superclass") { |options| options.root = root }
+    dir = run_generator(File.join(root, "lib/duplicates.rb"), "distinct namespaces") { |options| options.root = root }
 
     assert_path_exists File.join(dir, "Root/Thing.md")
-    refute_path_exists File.join(dir, "Root/Inner/Root/Thing.md")
+    assert_path_exists File.join(dir, "Root/Inner/Root/Thing.md")
+    assert_path_exists File.join(dir, "Root/Inner/Root/Undocumented.md")
     thing_doc = File.read(File.join(dir, "Root/Thing.md"))
+    nested_thing_doc = File.read(File.join(dir, "Root/Inner/Root/Thing.md"))
     entries = index_entries(dir)
 
     %w[real_one real_two].each do |method|
@@ -202,21 +204,23 @@ class TestGenerator < Minitest::Test
       assert_includes entries, ["Root::Thing.#{method}", "Method", "Root/Thing.md#method-i-#{method}"]
     end
 
-    refute_includes thing_doc, "#### `synthetic()`"
+    assert_includes nested_thing_doc, "#### `synthetic()`"
+    assert_includes nested_thing_doc, "## Synthetic category"
+    assert_includes entries,
+      ["Root::Inner::Root::Thing.synthetic", "Method", "Root/Inner/Root/Thing.md#method-i-synthetic"]
     child_table = Nokogiri::HTML.fragment(Commonmarker.to_html(File.read(File.join(dir, "Child.md")))).at_css("table")
     child_inheritance = child_table.at_css("tbody tr")
 
     assert_eql ["Inherits", "Root::Inner::Root::Thing"], child_inheritance.css("td").map(&:text)
-    assert_eql ["Root/Thing.md"], child_inheritance.css("a").map { |link| link["href"] }
+    assert_eql ["Root/Inner/Root/Thing.md"], child_inheritance.css("a").map { |link| link["href"] }
 
-    refute_path_exists File.join(dir, "Root/Undocumented.md")
     unlinked_child_table = Nokogiri::HTML.fragment(
       Commonmarker.to_html(File.read(File.join(dir, "UnlinkedChild.md")))
     ).at_css("table")
     unlinked_child_inheritance = unlinked_child_table.at_css("tbody tr")
 
     assert_eql ["Inherits", "Root::Inner::Root::Undocumented"], unlinked_child_inheritance.css("td").map(&:text)
-    assert_empty unlinked_child_inheritance.css("a")
+    assert_eql ["Root/Inner/Root/Undocumented.md"], unlinked_child_inheritance.css("a").map { |link| link["href"] }
   end
 
   def test_generator_renders_untitled_sections_for_external_namespaces

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -9,7 +9,6 @@ require "rdoc/markdown"
 require "rdiscount"
 
 class TestGenerator < Minitest::Test
-  cover "RDoc::Generator::Markdown#class_renderable?"
   cover "RDoc::Generator::Markdown#metadata_reference"
   cover "RDoc::Generator::Markdown#method_signature"
   cover "RDoc::Generator::Markdown#render_description"

--- a/test/test_markdown_helpers.rb
+++ b/test/test_markdown_helpers.rb
@@ -588,9 +588,11 @@ class TestMarkdownHelpers < Minitest::Test
     klass.add_method(constructor)
     klass.add_method(method)
     klass.add_method(rdoc_method("plain", visible: true))
+    class_formatter = klass.formatter
 
     markdown = read_generated("Docs/Thing.md", classes: [klass])
 
+    assert_same klass, class_formatter.code_object
     assert_includes markdown, "# Class Docs::Thing"
     assert_includes markdown, "# Class Topic"
     refute_includes markdown, "## Class Topic"
@@ -598,6 +600,7 @@ class TestMarkdownHelpers < Minitest::Test
     assert_includes markdown, "# Class Topic<a id=\"class-docs-thing-class-topic\"></a>\n\n### Constants"
     assert_includes markdown, "#### `VALUE`<a id=\"VALUE\"></a>\nNot documented."
     assert_includes markdown, "## Overview"
+    assert_includes markdown, '<a id="Overview-label-Section+Topic"></a>'
     assert_includes markdown, "### Section Topic"
     refute_includes markdown, "\n# Section Topic\n"
     assert_includes markdown, "#### `run()`"

--- a/test/test_markdown_helpers.rb
+++ b/test/test_markdown_helpers.rb
@@ -263,7 +263,8 @@ class TestMarkdownHelpers < Minitest::Test
     options.locale = locale
     store = RDoc::Store.new(options)
     klass = rdoc_class("Localized", comment: "Class body", store: store)
-    klass.add_section("Details", RDoc::Comment.new("Section body"))
+    section_comment = RDoc::Comment.new("Section body")
+    klass.add_section("Details", section_comment)
     store.classes_hash[klass.full_name] = klass
     store.complete(:public)
 
@@ -272,6 +273,26 @@ class TestMarkdownHelpers < Minitest::Test
 
     assert_includes markdown, "Translated introduction"
     assert_includes markdown, "Translated details"
+    assert_equal "Section body", section_comment.text
+  end
+
+  def test_localized_markdown_sections_keep_their_markup_format
+    locale = Object.new
+    locale.define_singleton_method(:translate) { |text| text }
+    options = generator_options(op_dir: stable_tmpdir("localized-markdown-section"))
+    options.locale = locale
+    store = RDoc::Store.new(options)
+    klass = rdoc_class("LocalizedMarkdown", store: store)
+    comment = RDoc::Comment.new("A [link](https://example.test)", klass.in_files.first)
+    comment.format = "markdown"
+    klass.add_section("Details", comment)
+    store.classes_hash[klass.full_name] = klass
+    store.complete(:public)
+
+    RDoc::Generator::Markdown.new(store, options).generate
+    markdown = File.read(File.join(options.op_dir, "LocalizedMarkdown.md"))
+
+    assert_includes markdown, "## Details\n\nA [link](https://example.test)\n"
   end
 
   def test_markdownify_accepts_frozen_converter_output

--- a/test/test_markdown_helpers.rb
+++ b/test/test_markdown_helpers.rb
@@ -295,6 +295,25 @@ class TestMarkdownHelpers < Minitest::Test
     assert_includes markdown, "## Details\n\nA [link](https://example.test)\n"
   end
 
+  def test_localized_sections_preserve_document_backed_comments
+    options = generator_options(op_dir: stable_tmpdir("localized-document-section"))
+    options.locale = Object.new.tap { |locale| locale.define_singleton_method(:translate) { |text| text } }
+    store = RDoc::Store.new(options)
+    klass = rdoc_class("LocalizedDocument", store: store)
+    document = RDoc::Markup::Document.new(RDoc::Markup::Paragraph.new("Section body"))
+    klass.add_section("Details", RDoc::Comment.from_document(document))
+    document = RDoc::Markup::Document.new(RDoc::Markup::Paragraph.new("More details"))
+    klass.add_section("Details", RDoc::Comment.from_document(document))
+    store.classes_hash[klass.full_name] = klass
+    store.complete(:public)
+
+    RDoc::Generator::Markdown.new(store, options).generate
+    markdown = File.read(File.join(options.op_dir, "LocalizedDocument.md"))
+
+    assert_includes markdown, "## Details\n\nSection body\n"
+    assert_includes markdown, "More details"
+  end
+
   def test_markdownify_accepts_frozen_converter_output
     page = raw_html_page(
       relative_name: "frozen.rdoc",

--- a/test/test_markdown_helpers.rb
+++ b/test/test_markdown_helpers.rb
@@ -277,13 +277,15 @@ class TestMarkdownHelpers < Minitest::Test
   end
 
   def test_localized_markdown_sections_keep_their_markup_format
+    source = "A [link](https://example.test)"
+    translation = "Translated [link](https://example.test)"
     locale = Object.new
-    locale.define_singleton_method(:translate) { |text| text }
+    locale.define_singleton_method(:translate) { |_text| translation }
     options = generator_options(op_dir: stable_tmpdir("localized-markdown-section"))
     options.locale = locale
     store = RDoc::Store.new(options)
     klass = rdoc_class("LocalizedMarkdown", store: store)
-    comment = RDoc::Comment.new("A [link](https://example.test)", klass.in_files.first)
+    comment = RDoc::Comment.new(source, klass.in_files.first)
     comment.format = "markdown"
     klass.add_section("Details", comment)
     store.classes_hash[klass.full_name] = klass
@@ -292,7 +294,8 @@ class TestMarkdownHelpers < Minitest::Test
     RDoc::Generator::Markdown.new(store, options).generate
     markdown = File.read(File.join(options.op_dir, "LocalizedMarkdown.md"))
 
-    assert_includes markdown, "## Details\n\nA [link](https://example.test)\n"
+    assert_includes markdown, "## Details\n\n#{translation}\n"
+    assert_equal source, comment.text
   end
 
   def test_localized_sections_preserve_document_backed_comments

--- a/test/test_markdown_helpers.rb
+++ b/test/test_markdown_helpers.rb
@@ -696,6 +696,39 @@ class TestMarkdownHelpers < Minitest::Test
     assert_false File.exist?(File.join(dir, "HiddenOwner.md"))
   end
 
+  def test_same_page_method_aliases_do_not_link_to_hidden_targets
+    klass = build_rdoc_class(full_name: "Aliases", description: "Alias docs")
+    target = rdoc_method("secret", visible: false)
+    alias_method = rdoc_method("exposed", visible: true)
+    alias_method.is_alias_for = target
+    klass.add_method(target)
+    klass.add_method(alias_method)
+
+    markdown = read_generated("Aliases.md", classes: [klass])
+
+    assert_includes markdown, "Alias for: `secret`"
+    refute_includes markdown, "Alias for: [`secret`]"
+    refute_includes markdown, "#### `secret()"
+  end
+
+  def test_cross_page_method_aliases_do_not_link_to_hidden_targets
+    aliases = build_rdoc_class(full_name: "Aliases", description: "Alias docs")
+    owner = build_rdoc_class(full_name: "Owner", description: "Owner docs")
+    target = rdoc_method("secret", visible: false)
+    alias_method = rdoc_method("exposed", visible: true)
+    alias_method.is_alias_for = target
+    aliases.add_method(alias_method)
+    owner.add_method(target)
+
+    dir = generate_markdown(classes: [aliases, owner])
+    alias_markdown = File.read(File.join(dir, "Aliases.md"))
+    owner_markdown = File.read(File.join(dir, "Owner.md"))
+
+    assert_includes alias_markdown, "Alias for: `secret`"
+    refute_includes alias_markdown, "Alias for: [`secret`]"
+    refute_includes owner_markdown, "#### `secret()"
+  end
+
   def test_method_alias_links_to_distinct_repeated_namespace
     discarded = build_rdoc_class(full_name: "Real::Inner::Real::Thing", description: "Discarded")
     aliases = build_rdoc_class(full_name: "Aliases", description: "Alias docs")

--- a/test/test_markdown_helpers.rb
+++ b/test/test_markdown_helpers.rb
@@ -37,7 +37,7 @@ class TestMarkdownHelpers < Minitest::Test
     options.markdown_unknown_tags = markdown_unknown_tags unless markdown_unknown_tags.equal?(DEFAULT_MARKDOWN_UNKNOWN_TAGS)
 
     RDoc::Generator::Markdown.new(
-      rdoc_store(classes: classes, pages: pages),
+      rdoc_store(classes: classes, pages: pages, options: options),
       options
     ).generate
     dir

--- a/test/test_markdown_helpers.rb
+++ b/test/test_markdown_helpers.rb
@@ -245,14 +245,37 @@ class TestMarkdownHelpers < Minitest::Test
 
   def test_generator_applies_crossref_policy_only_while_rendering
     page = rdoc_page(relative_name: "guide.rdoc", comment: "Hidden")
-    hidden = build_rdoc_class(full_name: "Hidden")
-    hidden.add_method(rdoc_method("hidden_method", visible: false))
+    hidden = RDoc::NormalModule.new("Hidden")
 
     markdown = read_generated("guide_rdoc.md", classes: [hidden], pages: [page])
 
     assert_includes markdown, "`Hidden`"
     refute_includes markdown, "[`Hidden`]"
     assert_includes page.description, '<a href="Hidden.html"><code>Hidden</code></a>'
+  end
+
+  def test_section_descriptions_use_the_configured_locale
+    locale = Object.new
+    locale.define_singleton_method(:translate) do |text|
+      {"Class body" => "Translated introduction", "Section body" => "Translated details"}.fetch(text, text)
+    end
+    options = generator_options(op_dir: stable_tmpdir("localized-sections"))
+    options.locale = locale
+    store = RDoc::Store.new(options)
+    source = store.add_file("localized.rb")
+    klass = RDoc::NormalClass.new("Localized")
+    klass.store = store
+    klass.record_location(source)
+    klass.add_comment(RDoc::Comment.new("Class body"), source)
+    klass.add_section("Details", RDoc::Comment.new("Section body"))
+    store.classes_hash[klass.full_name] = klass
+    store.complete(:public)
+
+    RDoc::Generator::Markdown.new(store, options).generate
+    markdown = File.read(File.join(options.op_dir, "Localized.md"))
+
+    assert_includes markdown, "Translated introduction"
+    assert_includes markdown, "Translated details"
   end
 
   def test_markdownify_accepts_frozen_converter_output
@@ -638,7 +661,7 @@ class TestMarkdownHelpers < Minitest::Test
     assert_includes markdown, "Alias for: [`find`](../OtherAliases.md#method-i-find)"
   end
 
-  def test_method_alias_cannot_link_to_discarded_duplicate
+  def test_method_alias_links_to_distinct_repeated_namespace
     selected = build_rdoc_class(full_name: "Real::Thing", description: "Selected", methods: 2)
     discarded = build_rdoc_class(full_name: "Real::Inner::Real::Thing", description: "Discarded")
     aliases = build_rdoc_class(full_name: "Aliases", description: "Alias docs")
@@ -648,7 +671,9 @@ class TestMarkdownHelpers < Minitest::Test
     discarded.add_method(ghost)
     aliases.add_method(alias_method)
 
-    assert_raises(KeyError) { generate_markdown(classes: [selected, discarded, aliases]) }
+    markdown = read_generated("Aliases.md", classes: [selected, discarded, aliases])
+
+    assert_includes markdown, "Alias for: [`ghost`](Real/Inner/Real/Thing.md#method-i-ghost)"
   end
 
   def test_generated_markdown_collapses_blank_lines_and_strips_line_endings

--- a/test/test_markdown_helpers.rb
+++ b/test/test_markdown_helpers.rb
@@ -262,11 +262,7 @@ class TestMarkdownHelpers < Minitest::Test
     options = generator_options(op_dir: stable_tmpdir("localized-sections"))
     options.locale = locale
     store = RDoc::Store.new(options)
-    source = store.add_file("localized.rb")
-    klass = RDoc::NormalClass.new("Localized")
-    klass.store = store
-    klass.record_location(source)
-    klass.add_comment(RDoc::Comment.new("Class body"), source)
+    klass = rdoc_class("Localized", comment: "Class body", store: store)
     klass.add_section("Details", RDoc::Comment.new("Section body"))
     store.classes_hash[klass.full_name] = klass
     store.complete(:public)
@@ -662,7 +658,6 @@ class TestMarkdownHelpers < Minitest::Test
   end
 
   def test_method_alias_links_to_distinct_repeated_namespace
-    selected = build_rdoc_class(full_name: "Real::Thing", description: "Selected", methods: 2)
     discarded = build_rdoc_class(full_name: "Real::Inner::Real::Thing", description: "Discarded")
     aliases = build_rdoc_class(full_name: "Aliases", description: "Alias docs")
     ghost = rdoc_method("ghost", visible: true)
@@ -671,7 +666,7 @@ class TestMarkdownHelpers < Minitest::Test
     discarded.add_method(ghost)
     aliases.add_method(alias_method)
 
-    markdown = read_generated("Aliases.md", classes: [selected, discarded, aliases])
+    markdown = read_generated("Aliases.md", classes: [discarded, aliases])
 
     assert_includes markdown, "Alias for: [`ghost`](Real/Inner/Real/Thing.md#method-i-ghost)"
   end

--- a/test/test_markdown_helpers.rb
+++ b/test/test_markdown_helpers.rb
@@ -678,6 +678,24 @@ class TestMarkdownHelpers < Minitest::Test
     assert_includes markdown, "Alias for: [`find`](../OtherAliases.md#method-i-find)"
   end
 
+  def test_method_aliases_do_not_link_to_omitted_owners
+    aliases = build_rdoc_class(full_name: "Aliases", description: "Alias docs")
+    hidden_owner = build_rdoc_class(full_name: "HiddenOwner", description: "Hidden docs")
+    target = rdoc_method("secret", visible: true)
+    alias_method = rdoc_method("exposed", visible: true)
+    alias_method.is_alias_for = target
+    aliases.add_method(alias_method)
+    hidden_owner.add_method(target)
+    hidden_owner.done_documenting = true
+
+    dir = generate_markdown(classes: [aliases, hidden_owner])
+    markdown = File.read(File.join(dir, "Aliases.md"))
+
+    assert_includes markdown, "Alias for: `secret`"
+    refute_includes markdown, "Alias for: [`secret`]"
+    assert_false File.exist?(File.join(dir, "HiddenOwner.md"))
+  end
+
   def test_method_alias_links_to_distinct_repeated_namespace
     discarded = build_rdoc_class(full_name: "Real::Inner::Real::Thing", description: "Discarded")
     aliases = build_rdoc_class(full_name: "Aliases", description: "Alias docs")

--- a/test/test_rails_harness.rb
+++ b/test/test_rails_harness.rb
@@ -55,15 +55,5 @@ class TestRailsHarness < Minitest::Test
     assert_includes entries,
       ["ActiveSupport::HashWithIndifferentAccess", "Class", "ActiveSupport/HashWithIndifferentAccess.md"]
     assert_includes entries, ["README", "File", "activerecord/README_rdoc.md"]
-
-    [
-      ["Process", "Module", "Process.md"],
-      ["Thread", "Module", "Thread.md"],
-      ["Thread::Backtrace", "Module", "Thread/Backtrace.md"],
-      ["URI", "Module", "URI.md"]
-    ].each do |entry|
-      refute_path_exists File.join(out_dir, entry.last)
-      refute_includes entries, entry
-    end
   end
 end

--- a/test/test_rails_harness.rb
+++ b/test/test_rails_harness.rb
@@ -54,7 +54,16 @@ class TestRailsHarness < Minitest::Test
 
     assert_includes entries,
       ["ActiveSupport::HashWithIndifferentAccess", "Class", "ActiveSupport/HashWithIndifferentAccess.md"]
-    assert_eql 1, entries.count { |name, type, _path| name == "ActiveSupport::HashWithIndifferentAccess" && type == "Class" }
     assert_includes entries, ["README", "File", "activerecord/README_rdoc.md"]
+
+    [
+      ["Process", "Module", "Process.md"],
+      ["Thread", "Module", "Thread.md"],
+      ["Thread::Backtrace", "Module", "Thread/Backtrace.md"],
+      ["URI", "Module", "URI.md"]
+    ].each do |entry|
+      refute_path_exists File.join(out_dir, entry.last)
+      refute_includes entries, entry
+    end
   end
 end

--- a/test/test_rails_harness.rb
+++ b/test/test_rails_harness.rb
@@ -54,8 +54,7 @@ class TestRailsHarness < Minitest::Test
 
     assert_includes entries,
       ["ActiveSupport::HashWithIndifferentAccess", "Class", "ActiveSupport/HashWithIndifferentAccess.md"]
+    assert_eql 1, entries.count { |name, type, _path| name == "ActiveSupport::HashWithIndifferentAccess" && type == "Class" }
     assert_includes entries, ["README", "File", "activerecord/README_rdoc.md"]
-
-    refute(entries.any? { |name, _type, _path| name.match?(/([A-Za-z_][A-Za-z0-9_]*)::.*::\1::/) })
   end
 end


### PR DESCRIPTION
Huge rewrite that removes scoring/rating logic completely and gives documents better structure. 

As a result, some other improvements include:
- This also removes namespace/classes that are not in the library
- Shows aliases properly
- Linking between documents should be better as well

